### PR TITLE
feat: Add additional features to `cargo-reaper run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "colored",
  "dirs",
  "gix",
+ "humantime",
  "reqwest",
  "serde",
  "tempfile",
@@ -323,7 +324,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -475,7 +476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1242,6 +1243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,7 +1461,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1829,7 +1836,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1982,7 +1989,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2232,7 +2239,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2684,7 +2691,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ codespan-reporting = "0.12"
 colored = "3"
 dirs = "6"
 gix = { version = "0.72", default-features = false }
+humantime = "2.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "blocking",
   "rustls-tls",

--- a/flake.nix
+++ b/flake.nix
@@ -368,6 +368,9 @@
           mdbook
           self.packages.${system}.default
           reaper
+        ] ++ lib.optionals pkgs.stdenv.isLinux [
+          xvfb-run
+          xdotool
         ];
       };
 

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -1,4 +1,4 @@
-use std::{io, path, process};
+use std::{io, path, process, thread, time};
 
 use crate::util::{self, BINARY_NAME, Colorize};
 
@@ -10,7 +10,11 @@ use crate::util::{self, BINARY_NAME, Colorize};
 /// # Usage
 ///
 /// This is run automatically when running the `cargo reaper run` command.
-pub(crate) fn run(override_binary: Option<path::PathBuf>) -> anyhow::Result<()> {
+pub(crate) fn run(
+    override_binary: Option<path::PathBuf>,
+    project: Option<path::PathBuf>,
+    timeout: Option<time::Duration>,
+) -> anyhow::Result<()> {
     override_binary
         .inspect(|reaper| {
             println!(
@@ -20,26 +24,125 @@ pub(crate) fn run(override_binary: Option<path::PathBuf>) -> anyhow::Result<()> 
             )
         })
         .or_else(|| which::which(BINARY_NAME).ok())
-        .map_or_else(run_global_default, |reaper| {
-            println!(
-                "     {} REAPER executable ({})",
-                "Running".green().bold(),
-                reaper.display(),
-            );
+        .map_or_else(
+            || run_global_default(project.as_ref(), timeout.as_ref()),
+            |reaper| {
+                println!(
+                    "     {} REAPER executable ({})",
+                    "Running".green().bold(),
+                    reaper.display(),
+                );
 
-            process::Command::new(reaper)
-                .stdin(process::Stdio::inherit())
-                .stdout(process::Stdio::inherit())
-                .stderr(process::Stdio::inherit())
-                .status()
+                timeout.map_or_else(
+                    || run_reaper(&reaper, project.as_ref())?.wait(),
+                    |timeout| {
+                        let (mut reaper, start) = run_reaper(&reaper, project.as_ref())
+                            .map(|reaper| (reaper, time::Instant::now()))?;
+
+                        loop {
+                            match reaper.try_wait()? {
+                                Some(status) => break Ok(status),
+                                None if start.elapsed() >= timeout => {
+                                    reaper.kill()?;
+                                    break reaper.wait();
+                                }
+                                None => thread::sleep(time::Duration::from_secs(1)),
+                            }
+                        }
+                    },
+                )
+            },
+        )
+        .map_err(|err| anyhow::anyhow!("While attempting to run REAPER executable: {err:?}"))?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn run_headless(
+    override_binary: Option<path::PathBuf>,
+    project: Option<path::PathBuf>,
+    display: String,
+    window_title: Option<String>,
+    timeout: Option<time::Duration>,
+) -> anyhow::Result<()> {
+    override_binary
+        .inspect(|reaper| {
+            println!(
+                "{}: overridng REAPER executable path ({})",
+                "warning".yellow().bold(),
+                reaper.display()
+            )
         })
+        .or_else(|| which::which(BINARY_NAME).ok())
+        .map_or_else(
+            || {
+                run_global_default_headless(
+                    project.as_ref(),
+                    &display,
+                    window_title.as_deref(),
+                    timeout.as_ref(),
+                )
+            },
+            |reaper| {
+                println!(
+                    "     {} REAPER executable ({})",
+                    "Running".green().bold(),
+                    reaper.display(),
+                );
+
+                timeout.map_or_else(
+                    || run_reaper_headless(&reaper, project.as_ref(), &display)?.wait(),
+                    |timeout| {
+                        let (mut reaper, start) =
+                            run_reaper_headless(&reaper, project.as_ref(), &display)
+                                .map(|reaper| (reaper, time::Instant::now()))?;
+
+                        loop {
+                            if let Some(window_title) = &window_title {
+                                const XDOTOOL: &str = "xdotool";
+                                const XDOTOOL_ARGS: &[&str; 2] = &["search", "--name"];
+                                if process::Command::new(XDOTOOL)
+                                    .args(XDOTOOL_ARGS)
+                                    .arg(window_title)
+                                    .env("DISPLAY", &display)
+                                    .output()
+                                    .map(|output| output.status.success())
+                                    .unwrap_or(false)
+                                {
+                                    reaper.kill()?;
+                                    reaper.wait()?;
+                                    process::exit(0);
+                                }
+                            }
+                            match reaper.try_wait()? {
+                                Some(_) if window_title.is_some() => process::exit(1),
+                                Some(status) => break Ok(status),
+                                None if start.elapsed() >= timeout => {
+                                    reaper.kill()?;
+                                    let status = reaper.wait();
+                                    if window_title.is_some() {
+                                        process::exit(1);
+                                    }
+                                    break status;
+                                }
+                                None => thread::sleep(time::Duration::from_secs(1)),
+                            }
+                        }
+                    },
+                )
+            },
+        )
         .map_err(|err| anyhow::anyhow!("While attempting to run REAPER executable: {err:?}"))?;
 
     Ok(())
 }
 
 /// Run the global default REAPER binary executable.
-fn run_global_default() -> io::Result<process::ExitStatus> {
+fn run_global_default(
+    project: Option<&path::PathBuf>,
+    timeout: Option<&time::Duration>,
+) -> io::Result<process::ExitStatus> {
     util::os::locate_global_default().and_then(|reaper| {
         println!(
             "     {} global default REAPER executable ({})",
@@ -47,10 +150,111 @@ fn run_global_default() -> io::Result<process::ExitStatus> {
             reaper.display(),
         );
 
-        process::Command::new(reaper)
-            .stdin(process::Stdio::inherit())
-            .stdout(process::Stdio::inherit())
-            .stderr(process::Stdio::inherit())
-            .status()
+        timeout.map_or_else(
+            || run_reaper(&reaper, project)?.wait(),
+            |timeout| {
+                let (mut reaper, start) =
+                    run_reaper(&reaper, project).map(|reaper| (reaper, time::Instant::now()))?;
+
+                loop {
+                    match reaper.try_wait()? {
+                        Some(status) => break Ok(status),
+                        None if start.elapsed() >= *timeout => {
+                            reaper.kill()?;
+                            break reaper.wait();
+                        }
+                        None => thread::sleep(time::Duration::from_secs(1)),
+                    }
+                }
+            },
+        )
     })
+}
+
+#[cfg(target_os = "linux")]
+fn run_global_default_headless(
+    project: Option<&path::PathBuf>,
+    display: &str,
+    window_title: Option<&str>,
+    timeout: Option<&time::Duration>,
+) -> io::Result<process::ExitStatus> {
+    util::os::locate_global_default().and_then(|reaper| {
+        println!(
+            "     {} global default REAPER executable ({})",
+            "Running".green().bold(),
+            reaper.display(),
+        );
+
+        timeout.map_or_else(
+            || run_reaper_headless(&reaper, project, display)?.wait(),
+            |timeout| {
+                let (mut reaper, start) = run_reaper_headless(&reaper, project, display)
+                    .map(|reaper| (reaper, time::Instant::now()))?;
+
+                loop {
+                    if let Some(window_title) = &window_title {
+                        const XDOTOOL: &str = "xdotool";
+                        const XDOTOOL_ARGS: &[&str; 2] = &["search", "--name"];
+                        if process::Command::new(XDOTOOL)
+                            .args(XDOTOOL_ARGS)
+                            .arg(window_title)
+                            .env("DISPLAY", &display)
+                            .output()
+                            .map(|output| output.status.success())
+                            .unwrap_or(false)
+                        {
+                            reaper.kill()?;
+                            reaper.wait()?;
+                            process::exit(0);
+                        }
+                    }
+                    match reaper.try_wait()? {
+                        Some(_) if window_title.is_some() => process::exit(1),
+                        Some(status) => break Ok(status),
+                        None if start.elapsed() >= *timeout => {
+                            reaper.kill()?;
+                            let status = reaper.wait();
+                            if window_title.is_some() {
+                                process::exit(1);
+                            }
+                            break status;
+                        }
+                        None => thread::sleep(time::Duration::from_secs(1)),
+                    }
+                }
+            },
+        )
+    })
+}
+
+fn run_reaper(
+    reaper: &path::PathBuf,
+    project: Option<&path::PathBuf>,
+) -> io::Result<process::Child> {
+    process::Command::new(reaper)
+        .args(project.iter())
+        .stdin(process::Stdio::inherit())
+        .stdout(process::Stdio::inherit())
+        .stderr(process::Stdio::inherit())
+        .spawn()
+}
+
+#[cfg(target_os = "linux")]
+fn run_reaper_headless(
+    reaper: &path::PathBuf,
+    project: Option<&path::PathBuf>,
+    display: &str,
+) -> io::Result<process::Child> {
+    const XVFB_RUN: &str = "xvfb-run";
+    const XVFB_RUN_ARGS: &[&str; 1] = &["-a"];
+
+    process::Command::new(XVFB_RUN)
+        .args(XVFB_RUN_ARGS)
+        .arg(reaper)
+        .args(project.iter())
+        .env("DISPLAY", display)
+        .stdin(process::Stdio::inherit())
+        .stdout(process::Stdio::inherit())
+        .stderr(process::Stdio::inherit())
+        .spawn()
 }


### PR DESCRIPTION
Closes #17 

This removes the bash scripts that were used to run CI checks and adds that functionality to the `run` subcommand.