### PR TITLE
feat: Add shell completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
-/completions
 result*
 docs/book
 .nixos-test-history

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/completions
 result*
 docs/book
 .nixos-test-history

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "anyhow",
  "cargo_toml",
  "clap",
+ "clap_complete",
  "codespan-reporting",
  "colored",
  "dirs",
@@ -275,6 +276,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -292,7 +292,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -416,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1383,7 +1383,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1717,7 +1717,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1870,7 +1870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2120,7 +2120,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2571,7 +2571,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,16 @@ name = "cargo-reaper"
 version = "0.2.0"
 authors = ["Cloud Scythe Labs <cloudscythelabs@gmail.com>"]
 description = "A Cargo plugin for developing REAPER extension plugins with Rust."
+build = "build.rs"
 edition = "2024"
 license = "MIT"
 readme = "README.md"
 publish = true
+
+[build-dependencies]
+clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = "4.5"
+humantime = "2.2"
 
 [dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,14 @@ publish = true
 [build-dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
+colored = "3"
 humantime = "2.2"
 
 [dependencies]
 anyhow = "1"
 cargo_toml = "0.22"
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = "4.5"
 codespan-reporting = "0.12"
 colored = "3"
 dirs = "6"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+include!("src/cli.rs");
+
+fn main() -> std::io::Result<()> {
+    let outdir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("completions");
+
+    let mut cmd = CargoReaperArgs::command();
+    for &shell in clap_complete::Shell::value_variants() {
+        clap_complete::generate_to(shell, &mut cmd, "cargo-reaper", &outdir)?;
+    }
+
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,25 @@
+// Generates shell completions in `/target/completions`.
+//
+// See https://docs.rs/clap_complete/latest/clap_complete/index.html for more information.
+
 include!("src/cli.rs");
 
-fn main() -> std::io::Result<()> {
-    let outdir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("completions");
+fn main() {
+    let outdir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("completions");
+    println!("cargo::rerun-if-changed=src/cli.rs");
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=${}", outdir.display());
+
+    if let Err(err) = std::fs::create_dir_all(&outdir) {
+        println!("cargo:warning=failed to create completions dir: {err:?}")
+    }
 
     let mut cmd = CargoReaperArgs::command();
     for &shell in clap_complete::Shell::value_variants() {
-        clap_complete::generate_to(shell, &mut cmd, "cargo-reaper", &outdir)?;
+        if let Err(err) = clap_complete::generate_to(shell, &mut cmd, "cargo-reaper", &outdir) {
+            println!("cargo:warning=failed to create completion script for {shell}: {err:?}")
+        }
     }
-
-    Ok(())
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,4 +11,5 @@
   - [`cargo-reaper link`](./commands/link.md)
   - [`cargo-reaper run`](./commands/run.md)
   - [`cargo-reaper clean`](./commands/clean.md)
+  - [`cargo-reaper completions`](./commands/completions.md)
 - [Appendix: Glossary](./appendix/glossary.md)

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -33,6 +33,9 @@ Each command is documented in its own section:
 [`cargo-reaper clean`](./commands/clean.md) </br>
   <dd>Remove generated symlinks and artifacts.</dd>
 
+[`cargo-reaper completions`](./commands/completions.md) </br>
+  <dd>Generate shell completions.</dd>
+
 `help` </br>
   <dd>Print help or the help of the given subcommand(s).</dd>
 

--- a/docs/src/commands/completions.md
+++ b/docs/src/commands/completions.md
@@ -1,0 +1,60 @@
+# cargo-reaper-completions
+
+## NAME
+cargo-reaper-completions -- Generate shell completion scripts.
+
+## SYNOPSIS
+`cargo-reaper completions` _shell_
+
+## DESCRIPTION
+Generate shell completions for the `cargo-reaper` command line application.
+
+The following shells are supported:
+- [Bash](#bash)
+- [Elvish](#elvish)
+- [Fish](#fish)
+- [PowerShell](#powershell)
+- [Zsh](#zsh)
+
+## OPTIONS
+
+`-h` </br>
+`--help` </br>
+  <dd>Print help information.</dd>
+
+## EXAMPLES
+
+Below are examples of how to generate completion scripts for the supported shells.
+Note that this does not include instructions for sourcing the scripts or configuring your shell to enable completions.
+Please refer to your shell’s documentation for details.
+
+### Bash
+
+```sh
+cargo-reaper completions bash > /usr/share/bash-completion/completions/cargo-reaper.bash
+```
+
+### Elvish
+
+```sh
+cargo-reaper completions elvish > ~/.elvish/lib/cargo-reaper.elv
+```
+
+### Fish
+
+```sh
+cargo-reaper completions fish > /usr/share/fish/vendor_completions.d/cargo-reaper.fish
+```
+
+### PowerShell
+
+```sh
+cargo-reaper completions powershell > $HOME/Documents/PowerShell/cargo-reaper.ps1
+```
+
+### Zsh
+
+```sh
+cargo-reaper completions zsh > /usr/share/zsh/site-functions/_cargo-reaper
+```
+

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,8 +1,21 @@
+<table>
+<tr>
+<td style="vertical-align: top; text-align: left; border: none; padding-left: 0;">
+
 # Introduction
 
-`cargo-reaper` is a Cargo plugin designed to streamline the development of REAPER extension plugins with Rust.
-It serves as a companion for the [`reaper-rs`](https://github.com/helgoboss/reaper-rs) library,
+`cargo-reaper` is a Cargo plugin designed to streamline the development of REAPER extension plugins with Rust.  
+It serves as a companion for the [`reaper-rs`](https://github.com/helgoboss/reaper-rs) library,  
 which provides Rust bindings and tools for creating REAPER plugins -- including a procedural macro that bootstraps your plugin as a native REAPER extension.
+
+</td>
+<td align="right" width="180" style="border: none;">
+
+<img src="https://raw.githubusercontent.com/Cloud-Scythe-Labs/cargo-reaper/refs/heads/master/assets/rea-corro.svg" alt="Corro the Unsafe Rust Urchin" width="150"/>
+
+</td>
+</tr>
+</table>
 
 ## Motivation
 

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,9 @@
         inherit src;
         strictDeps = true;
 
-        nativeBuildInputs = with pkgs; lib.optionals stdenv.isLinux [
+        nativeBuildInputs = with pkgs; [
+          installShellFiles
+        ] ++ lib.optionals stdenv.isLinux [
           autoPatchelfHook
         ];
 
@@ -82,6 +84,13 @@
       # artifacts from above.
       cargo-reaper-drv = craneLib.buildPackage (commonArgs // {
         inherit cargoArtifacts;
+        # NOTE: `installShellCompletion` only has support for Bash, Zsh and Fish
+        postInstallPhase = ''
+          installShellCompletion --cmd cargo-reaper \
+            --bash <($out/bin/cargo-reaper completions bash) \
+            --fish <($out/bin/cargo-reaper completions fish) \
+            --zsh <($out/bin/cargo-reaper completions zsh)
+        '';
         doCheck = false;
       });
     in

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,11 @@
-use std::{path, process, time};
+use std::{fmt, path, process, time};
 
-pub(crate) use clap::{CommandFactory, FromArgMatches};
+pub use clap::{CommandFactory, FromArgMatches};
 use clap::{Parser, ValueEnum, ValueHint};
 
 #[cfg(target_os = "linux")]
-use crate::util::DEFAULT_XSERVER_DISPLAY;
+/// The default display used by `Xvfb` for running REAPER in a headless environment.
+const DEFAULT_XSERVER_DISPLAY: &str = ":99";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -23,11 +24,11 @@ pub struct CargoReaperArgs {
 impl CargoReaperArgs {
     /// Creates the `clap::Command::after_help` message which shows the detected path
     /// to a REAPER binary executable, if any.
-    pub(crate) fn reaper_help_heading(reaper_bin_path: Option<&path::Path>) -> String {
+    pub fn reaper_help_heading(reaper_bin_path: Option<&path::Path>) -> String {
         format!(
             "{}\n  {}",
             "\x1b[4mREAPER:\x1b[0m",
-            crate::util::ReaperBinaryPath(reaper_bin_path)
+            ReaperBinaryPath(reaper_bin_path)
         )
     }
 }
@@ -164,8 +165,23 @@ pub enum CargoReaperCommand {
     },
 }
 
+/// The path to the REAPER binary executable.
+pub(crate) struct ReaperBinaryPath<'a>(pub(crate) Option<&'a path::Path>);
+impl fmt::Display for ReaperBinaryPath<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(reaper) = self.0 {
+            write!(f, "{}", reaper.display())
+        } else {
+            write!(
+                f,
+                "Unable to locate REAPER executable — download it at https://www.reaper.fm/download.php"
+            )
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, ValueEnum)]
-pub(crate) enum Stdio {
+pub enum Stdio {
     Piped,
     Inherit,
     Null,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,20 @@
 use std::{fmt, path, process, time};
 
 pub use clap::{CommandFactory, FromArgMatches};
-use clap::{Parser, ValueEnum, ValueHint};
+use clap::{Parser, ValueEnum, ValueHint, builder::styling};
+use colored::Colorize;
 
 #[cfg(target_os = "linux")]
 /// The default display used by `Xvfb` for running REAPER in a headless environment.
 const DEFAULT_XSERVER_DISPLAY: &str = ":99";
+
+/// The terminal output style configuration.
+pub const TERM_STYLE: styling::Styles = styling::Styles::styled()
+    .header(styling::AnsiColor::Green.on_default().bold())
+    .usage(styling::AnsiColor::Green.on_default().bold())
+    .literal(styling::AnsiColor::Cyan.on_default())
+    .placeholder(styling::AnsiColor::Cyan.on_default())
+    .valid(styling::AnsiColor::Cyan.on_default());
 
 #[derive(Debug, Parser)]
 #[command(
@@ -27,7 +36,7 @@ impl CargoReaperArgs {
     pub fn reaper_help_heading(reaper_bin_path: Option<&path::Path>) -> String {
         format!(
             "{}\n  {}",
-            "\x1b[4mREAPER:\x1b[0m",
+            "REAPER:".green().bold(),
             ReaperBinaryPath(reaper_bin_path)
         )
     }
@@ -74,8 +83,7 @@ pub enum CargoReaperCommand {
 
         /// Open a specific REAPER project file.
         #[arg(
-            long = "open-project",
-            alias = "open",
+            long = "open",
             short = 'o',
             value_name = "PROJECT",
             value_hint = ValueHint::FilePath
@@ -127,15 +135,15 @@ pub enum CargoReaperCommand {
         timeout: Option<time::Duration>,
 
         /// Configuration for the child process’s standard input (stdin) handle.
-        #[arg(long, value_name = "STDIO", default_value = "null")]
+        #[arg(long, short = 'I', value_name = "STDIO", default_value = "null")]
         stdin: Stdio,
 
         /// Configuration for the child process’s standard output (stdout) handle.
-        #[arg(long, value_name = "STDIO", default_value = "inherit")]
+        #[arg(long, short = 'O', value_name = "STDIO", default_value = "inherit")]
         stdout: Stdio,
 
         /// Configuration for the child process’s standard error (stderr) handle.
-        #[arg(long, value_name = "STDIO", default_value = "inherit")]
+        #[arg(long, short = 'E', value_name = "STDIO", default_value = "inherit")]
         stderr: Stdio,
 
         /// Arguments to forward to the `cargo build` invocation.
@@ -162,6 +170,16 @@ pub enum CargoReaperCommand {
         /// Remove artifacts that cargo-reaper has generated in the past.
         #[arg(long, short = 'a', default_value = "false")]
         remove_artifacts: bool,
+    },
+
+    /// Generate shell completions.
+    #[command(
+        after_help = format!("{} cargo-reaper completions bash > /usr/share/bash-completion/completions/cargo-reaper.bash", "Example:".green().bold())
+    )]
+    Completions {
+        /// The available shells to generate completion scripts.
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
     },
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,25 +7,6 @@ use crate::error::{Message, TomlErrorEmitter};
 /// The REAPER executable binary name.
 pub(crate) const BINARY_NAME: &str = "reaper";
 
-#[cfg(target_os = "linux")]
-/// The default display used by `Xvfb` for running REAPER in a headless environment.
-pub(crate) const DEFAULT_XSERVER_DISPLAY: &str = ":99";
-
-/// The path to the REAPER binary executable.
-pub(crate) struct ReaperBinaryPath<'a>(pub(crate) Option<&'a path::Path>);
-impl fmt::Display for ReaperBinaryPath<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(reaper) = self.0 {
-            write!(f, "{}", reaper.display())
-        } else {
-            write!(
-                f,
-                "Unable to locate REAPER executable — download it at https://www.reaper.fm/download.php"
-            )
-        }
-    }
-}
-
 /// Represents a REAPER plugin's manifest information.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct PluginManifest {


### PR DESCRIPTION
Closes #16 

Adds a `build.rs` which generates completions at `target/completions`, as well as on-demand with the `completions` subcommand. Adds documentation regarding completions usage.