### PR TITLE
fix: `cargo-reaper-build` cross compilation

### DIFF
--- a/.rust-toolchain.toml
+++ b/.rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.87.0"
-components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1774336807,
-        "narHash": "sha256-9Wu6fqKbjHBh//Rlx0p/jFVobZwgvBlBov2W2H1kfAI=",
+        "lastModified": 1781086641,
+        "narHash": "sha256-2oBncBeL671Tf6TnYqk36ebkfPHNYPKwz5at8NcrpvI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "2b5c85b86be24ff24e9586a56101e22f90ead9d4",
+        "rev": "640606300f74b4891bfa1a51f5756450f9fdc7f1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1780930886,
+        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -420,8 +420,8 @@
                 file_output=$(file $out/lib/reaper_package_ext.dll)
                 echo "$file_output"
                 echo "$file_output" |
-                  grep -q "PE32+ executable for MS Windows 5.02 (DLL), x86-64" || {
-                    echo "ERROR: not a PE32+ binary";
+                  grep -q "PE32+ executable for MS Windows.*(DLL), x86-64" || {
+                    echo "ERROR: not a PE32+ DLL";
                     exit 1;
                   }
               '';

--- a/flake.nix
+++ b/flake.nix
@@ -399,14 +399,13 @@
                 mingwCC
                 pkgs.wine64
               ];
-              buildInputs = [
-                crossPkgs.windows.pthreads
-              ];
               CARGO_BUILD_TARGET = rustcTarget;
               CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER =
                 "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
               "CC_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCC;
               "CXX_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCXX;
+              CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS =
+                "-L ${crossPkgs.windows.pthreads}/lib";
             };
             cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
           in

--- a/flake.nix
+++ b/flake.nix
@@ -454,14 +454,16 @@
 
                 imports=$(llvm-objdump -p $out/lib/reaper_package_ext.dll | grep "DLL Name")
                 echo "$imports"
-                echo "$imports" | grep -q "VCRUNTIME140.dll" || {
-                  echo "ERROR: VCRUNTIME140.dll not imported (not an MSVC ABI DLL)";
-                  exit 1;
-                }
-                echo "$imports" | grep -qiE "libgcc|libstdc\+\+|msvcrt\.dll" && {
-                  echo "ERROR: MinGW runtime imported (not an MSVC ABI DLL)";
-                  exit 1;
-                }
+                echo "$imports" |
+                  grep -q "VCRUNTIME140.dll" || {
+                    echo "ERROR: VCRUNTIME140.dll not imported (not an MSVC ABI DLL)";
+                    exit 1;
+                  }
+                echo "$imports" |
+                  grep -qiE "libgcc|libstdc\+\+|msvcrt\.dll" && {
+                    echo "ERROR: MinGW runtime imported (not an MSVC ABI DLL)";
+                    exit 1;
+                  }
                 true
               '';
             });

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
         "cargo"
         "rustfmt"
         "clippy"
+        "rust-src"
         "rust-analyzer"
       ];
       craneLib =

--- a/flake.nix
+++ b/flake.nix
@@ -372,7 +372,7 @@
             };
           test-cargo-reaper-build-cross-windows =
             let
-              inherit (pkgs.lib.systems.examples.mingw-ucrt-x86_64-llvm.rust) rustTarget;
+              inherit (pkgs.lib.systems.examples.mingw-ucrt-x86_64-llvm.rust) rustcTarget;
               crossPkgs = pkgs.pkgsCross.mingw-ucrt-x86_64-llvm;
               mingwCC = crossPkgs.stdenv.cc;
               crossCC = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
@@ -380,7 +380,7 @@
 
               rustWithWindowsTarget = fenix.packages.${system}.combine [
                 rustToolchain
-                (fenix.packages.${system}.targets.${rustTarget}.toolchainOf {
+                (fenix.packages.${system}.targets.${rustcTarget}.toolchainOf {
                   channel = "1.87.0";
                   sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
                 }).rust-std
@@ -394,11 +394,11 @@
               crossArgs = {
                 src = testFileset ./tests/plugin_manifests/package_manifest;
                 strictDeps = true;
-                CARGO_BUILD_TARGET = rustTarget;
+                CARGO_BUILD_TARGET = rustcTarget;
                 CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_LINKER =
                   "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-                "CC_${rustTarget}" = crossCC;
-                "CXX_${rustTarget}" = crossCXX;
+                "CC_${rustcTarget}" = crossCC;
+                "CXX_${rustcTarget}" = crossCXX;
 
                 # # Force lld as the linker backend (required for gnullvm) and point it at
                 # # LLVM's libunwind compiled for Windows (also required by gnullvm).
@@ -412,7 +412,7 @@
               cargoArtifacts = cargoArtifactsCross;
               package = "package_manifest";
               plugin = "reaper_package_ext";
-              target = rustTarget;
+              target = rustcTarget;
               doInstallCheck = true;
               installCheckPhase = ''
                 test -f $out/lib/reaper_package_ext.dll

--- a/flake.nix
+++ b/flake.nix
@@ -404,8 +404,6 @@
                 "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
               "CC_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCC;
               "CXX_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCXX;
-              CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS =
-                "-L ${crossPkgs.windows.pthreads}/lib";
             };
             cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
           in

--- a/flake.nix
+++ b/flake.nix
@@ -399,14 +399,13 @@
                 mingwCC
                 pkgs.wine64
               ];
-              buildInputs = [
-                crossPkgs.windows.pthreads  # scoped to crossPkgs, not pkgs
-              ];
               CARGO_BUILD_TARGET = rustcTarget;
               CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER =
                 "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
               "CC_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCC;
               "CXX_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCXX;
+              CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS =
+                "-L ${crossPkgs.windows.pthreads}/lib";
             };
             cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
           in

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,10 @@
     let
       pkgs = import nixpkgs {
         inherit system;
-        config.allowUnfree = true;
+        config = {
+          allowUnfree = true;
+          allowUnsupportedSystem = true;
+        };
       };
 
       inherit (pkgs) lib;
@@ -394,17 +397,18 @@
               crossArgs = {
                 src = testFileset ./tests/plugin_manifests/package_manifest;
                 strictDeps = true;
+
+                nativeBuildInputs = [
+                  mingwCC
+                  pkgs.llvmPackages.bintools
+                  pkgs.windows.pthreads
+                ];
+
                 CARGO_BUILD_TARGET = rustcTarget;
                 CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_LINKER =
                   "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
                 "CC_${rustcTarget}" = crossCC;
                 "CXX_${rustcTarget}" = crossCXX;
-
-                # # Force lld as the linker backend (required for gnullvm) and point it at
-                # # LLVM's libunwind compiled for Windows (also required by gnullvm).
-                # CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_RUSTFLAGS =
-                #   "-C link-arg=-fuse-ld=lld -C link-arg=-L${winUnwind}/lib";
-                nativeBuildInputs = [ mingwCC pkgs.llvmPackages.bintools crossPkgs.windows.pthreads ];
               };
               cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
             in

--- a/flake.nix
+++ b/flake.nix
@@ -373,7 +373,7 @@
           test-cargo-reaper-build-cross-windows =
             let
               target = "x86_64-pc-windows-gnullvm";
-              mingwCC = pkgs.pkgsCross.mingw-ucrt-x86_64.stdenv.cc;
+              mingwCC = pkgs.pkgsCross.mingw-ucrt-x86_64.llvmPackages.clang;
               rustWithWindowsTarget = fenix.packages.${system}.combine [
                 rustToolchain
                 (fenix.packages.${system}.targets.${target}.toolchainOf {

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
         config = {
           allowUnfree = true;
           allowUnsupportedSystem = true;
+          microsoftVisualStudioLicenseAccepted = true;
         };
       };
 
@@ -380,7 +381,7 @@
             };
           test-cargo-reaper-build-cross-windows =
             let
-              rustcTarget = "x86_64-pc-windows-gnu";
+              rustcTarget = "x86_64-pc-windows-msvc";
               craneLibCross =
                 let
                   rustWithWindowsTarget = fenix.packages.${system}.combine [
@@ -393,17 +394,30 @@
               crossArgs =
                 let
                   envTarget = builtins.replaceStrings [ "-" ] [ "_" ] rustcTarget;
-                  crossPkgs = pkgs.pkgsCross.mingwW64;
-                  mingwCC = crossPkgs.stdenv.cc;
+                  winSdk = pkgs.windows.sdk;
+                  llvm = pkgs.llvmPackages;
                 in
                 {
                   src = testFileset ./tests/plugin_manifests/package_manifest;
                   strictDeps = true;
-                  nativeBuildInputs = [ mingwCC ];
-                  "CC_${envTarget}" = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-                  "CXX_${envTarget}" = "${mingwCC}/bin/${mingwCC.targetPrefix}c++";
-                  CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-                  CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-L ${crossPkgs.windows.pthreads}/lib";
+                  nativeBuildInputs = [
+                    llvm.clang-unwrapped
+                    llvm.bintools-unwrapped
+                    llvm.llvm
+                  ];
+                  "CC_${envTarget}" = "${llvm.clang-unwrapped}/bin/clang-cl";
+                  "CXX_${envTarget}" = "${llvm.clang-unwrapped}/bin/clang-cl";
+                  # Pass SDK paths to clang-cl when the cc crate compiles C/C++ in build.rs scripts.
+                  "CFLAGS_${envTarget}" = "/vctoolsdir ${winSdk}/crt /winsdkdir ${winSdk}/sdk";
+                  "CXXFLAGS_${envTarget}" = "/vctoolsdir ${winSdk}/crt /winsdkdir ${winSdk}/sdk";
+                  # llvm-lib is the MSVC lib.exe equivalent; cc-rs invokes it with MSVC-style args.
+                  "AR_${envTarget}" = "${llvm.llvm}/bin/llvm-lib";
+                  CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER = "${llvm.bintools-unwrapped}/bin/lld-link";
+                  CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS = lib.concatStringsSep " " [
+                    "-C link-arg=/LIBPATH:${winSdk}/crt/lib/x64"
+                    "-C link-arg=/LIBPATH:${winSdk}/sdk/lib/ucrt/x64"
+                    "-C link-arg=/LIBPATH:${winSdk}/sdk/lib/um/x64"
+                  ];
                 };
               cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
             in

--- a/flake.nix
+++ b/flake.nix
@@ -417,7 +417,7 @@
               doInstallCheck = true;
               installCheckPhase = ''
                 test -f $out/lib/reaper_package_ext.dll
-                file $out/lib/reaper_package_ext.dll
+                file $out/lib/reaper_package_ext.dll | grep -q "PE32+ executable (DLL) (GUI) x86-64, for MS Windows"
               '';
             });
         };

--- a/flake.nix
+++ b/flake.nix
@@ -372,8 +372,8 @@
             };
           test-cargo-reaper-build-cross-windows =
             let
-              inherit (pkgs.lib.systems.examples.mingw-ucrt-x86_64.rust) rustTarget;
-              crossPkgs = pkgs.pkgsCross.mingw-ucrt-x86_64;
+              inherit (pkgs.lib.systems.examples.mingw-ucrt-x86_64-llvm.rust) rustTarget;
+              crossPkgs = pkgs.pkgsCross.mingw-ucrt-x86_64-llvm;
               mingwCC = crossPkgs.stdenv.cc;
               crossCC = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
               crossCXX = "${mingwCC}/bin/${mingwCC.targetPrefix}c++";

--- a/flake.nix
+++ b/flake.nix
@@ -400,11 +400,12 @@
 
                 nativeBuildInputs = [
                   mingwCC
+                  pkgs.wine64
                   pkgs.llvmPackages.bintools
                 ];
 
                 buildInputs = [
-                  crossPkgs.windows.pthreads
+                  pkgs.windows.pthreads
                 ];
 
                 CARGO_BUILD_TARGET = rustcTarget;

--- a/flake.nix
+++ b/flake.nix
@@ -374,58 +374,52 @@
               };
             };
           test-cargo-reaper-build-cross-windows =
-            let
-              inherit (pkgs.lib.systems.examples.mingw-ucrt-x86_64-llvm.rust) rustcTarget;
-              crossPkgs = pkgs.pkgsCross.mingw-ucrt-x86_64-llvm;
-              mingwCC = crossPkgs.stdenv.cc;
-              crossCC = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-              crossCXX = "${mingwCC}/bin/${mingwCC.targetPrefix}c++";
-
-              rustWithWindowsTarget = fenix.packages.${system}.combine [
-                rustToolchain
-                (fenix.packages.${system}.targets.${rustcTarget}.toolchainOf {
-                  channel = "1.87.0";
-                  sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
-                }).rust-std
+          let
+            rustcTarget = "x86_64-pc-windows-gnu";
+            crossPkgs = pkgs.pkgsCross.mingwW64;
+            mingwCC = crossPkgs.stdenv.cc;
+            crossCC = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
+            crossCXX = "${mingwCC}/bin/${mingwCC.targetPrefix}c++";
+            rustWithWindowsTarget = fenix.packages.${system}.combine [
+              rustToolchain
+              (fenix.packages.${system}.targets.${rustcTarget}.toolchainOf {
+                channel = "1.87.0";
+                sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
+              }).rust-std
+            ];
+            craneLibCross =
+              let
+                craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
+              in
+              craneLib // (cargoReaper.crane { inherit craneLib; });
+            crossArgs = {
+              src = testFileset ./tests/plugin_manifests/package_manifest;
+              strictDeps = true;
+              nativeBuildInputs = [
+                mingwCC
+                pkgs.wine64
               ];
-              craneLibCross =
-                let
-                  craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
-                in
-                craneLib // (cargoReaper.crane { inherit craneLib; });
-
-              crossArgs = {
-                src = testFileset ./tests/plugin_manifests/package_manifest;
-                strictDeps = true;
-
-                nativeBuildInputs = [
-                  mingwCC
-                  pkgs.wine64
-                  pkgs.llvmPackages.bintools
-                ];
-
-                buildInputs = [
-                  pkgs.windows.pthreads
-                ];
-
-                CARGO_BUILD_TARGET = rustcTarget;
-                CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_LINKER =
-                  "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-                "CC_${rustcTarget}" = crossCC;
-                "CXX_${rustcTarget}" = crossCXX;
-              };
-              cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
-            in
-            craneLibCross.buildReaperExtension (crossArgs // {
-              cargoArtifacts = cargoArtifactsCross;
-              package = "package_manifest";
-              plugin = "reaper_package_ext";
-              target = rustcTarget;
-              doInstallCheck = true;
-              installCheckPhase = ''
-                test -f $out/lib/reaper_package_ext.dll
-              '';
-            });
+              buildInputs = [
+                crossPkgs.windows.pthreads  # scoped to crossPkgs, not pkgs
+              ];
+              CARGO_BUILD_TARGET = rustcTarget;
+              CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER =
+                "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
+              "CC_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCC;
+              "CXX_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCXX;
+            };
+            cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
+          in
+          craneLibCross.buildReaperExtension (crossArgs // {
+            cargoArtifacts = cargoArtifactsCross;
+            package = "package_manifest";
+            plugin = "reaper_package_ext";
+            target = rustcTarget;
+            doInstallCheck = true;
+            installCheckPhase = ''
+              test -f $out/lib/reaper_package_ext.dll
+            '';
+          });
         };
 
       packages = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -401,7 +401,10 @@
                 nativeBuildInputs = [
                   mingwCC
                   pkgs.llvmPackages.bintools
-                  pkgs.windows.pthreads
+                ];
+
+                buildInputs = [
+                  crossPkgs.windows.pthreads
                 ];
 
                 CARGO_BUILD_TARGET = rustcTarget;

--- a/flake.nix
+++ b/flake.nix
@@ -372,11 +372,14 @@
             };
           test-cargo-reaper-build-cross-windows =
             let
-              target = "x86_64-pc-windows-gnu";
-              mingwCC = pkgs.pkgsCross.mingwW64.stdenv.cc;
+              target = "x86_64-pc-windows-gnullvm";
+              mingwCC = pkgs.pkgsCross.mingw-ucrt-x86_64.stdenv.cc;
               rustWithWindowsTarget = fenix.packages.${system}.combine [
                 rustToolchain
-                fenix.packages.${system}.targets.${target}.latest.rust-std
+                (fenix.packages.${system}.toolchainOf {
+                  channel = "1.87.0";
+                  sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
+                }).targets.${target}.rust-std
               ];
               craneLibCross =
                 let base = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
@@ -385,7 +388,7 @@
                 src = testFileset ./tests/plugin_manifests/package_manifest;
                 strictDeps = true;
                 CARGO_BUILD_TARGET = target;
-                CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER =
+                CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_LINKER =
                   "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
                 nativeBuildInputs = [ mingwCC ];
               };

--- a/flake.nix
+++ b/flake.nix
@@ -400,7 +400,7 @@
                 pkgs.wine64
               ];
               buildInputs = [
-                pkgs.windows.pthreads
+                crossPkgs.windows.pthreads
               ];
               CARGO_BUILD_TARGET = rustcTarget;
               CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER =

--- a/flake.nix
+++ b/flake.nix
@@ -399,6 +399,9 @@
                 mingwCC
                 pkgs.wine64
               ];
+              buildInputs = [
+                pkgs.windows.pthreads
+              ];
               CARGO_BUILD_TARGET = rustcTarget;
               CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER =
                 "${mingwCC}/bin/${mingwCC.targetPrefix}cc";

--- a/flake.nix
+++ b/flake.nix
@@ -404,7 +404,7 @@
                 # # LLVM's libunwind compiled for Windows (also required by gnullvm).
                 # CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_RUSTFLAGS =
                 #   "-C link-arg=-fuse-ld=lld -C link-arg=-L${winUnwind}/lib";
-                nativeBuildInputs = [ mingwCC pkgs.llvmPackages.bintools ];
+                nativeBuildInputs = [ mingwCC pkgs.llvmPackages.bintools crossPkgs.windows.pthreads ];
               };
               cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
             in

--- a/flake.nix
+++ b/flake.nix
@@ -402,7 +402,6 @@
                   nativeBuildInputs = [ mingwCC ];
                   "CC_${envTarget}" = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
                   "CXX_${envTarget}" = "${mingwCC}/bin/${mingwCC.targetPrefix}c++";
-                  CARGO_BUILD_TARGET = rustcTarget;
                   CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
                   CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-L ${crossPkgs.windows.pthreads}/lib";
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,6 @@
       inherit (pkgs) lib;
       cargoReaper = self.mkLib {
         inherit lib;
-        inherit (pkgs) stdenv;
         inherit (self.packages.${system}) cargo-reaper;
       };
 
@@ -110,6 +109,11 @@
           commonTestArgs = src: {
             inherit src;
             strictDeps = true;
+          } // lib.optionalAttrs pkgs.stdenv.isLinux {
+            # Rust 1.96+ uses lld with -nodefaultlibs, which means libstdc++ is no
+            # longer implicitly findable at runtime in the Nix sandbox for test binaries
+            # compiled by cargo during the check phase.
+            LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];
           };
 
           testFileset = root: lib.fileset.toSource {
@@ -433,6 +437,7 @@
               doInstallCheck = true;
               installCheckPhase = ''
                 test -f $out/lib/reaper_package_ext.dll
+
                 file_output=$(file $out/lib/reaper_package_ext.dll)
                 echo "$file_output"
                 echo "$file_output" |
@@ -440,6 +445,18 @@
                     echo "ERROR: not a PE32+ DLL";
                     exit 1;
                   }
+
+                imports=$(llvm-objdump -p $out/lib/reaper_package_ext.dll | grep "DLL Name")
+                echo "$imports"
+                echo "$imports" | grep -q "VCRUNTIME140.dll" || {
+                  echo "ERROR: VCRUNTIME140.dll not imported (not an MSVC ABI DLL)";
+                  exit 1;
+                }
+                echo "$imports" | grep -qiE "libgcc|libstdc\+\+|msvcrt\.dll" && {
+                  echo "ERROR: MinGW runtime imported (not an MSVC ABI DLL)";
+                  exit 1;
+                }
+                true
               '';
             });
         };

--- a/flake.nix
+++ b/flake.nix
@@ -417,7 +417,9 @@
               doInstallCheck = true;
               installCheckPhase = ''
                 test -f $out/lib/reaper_package_ext.dll
-                file $out/lib/reaper_package_ext.dll | grep -q "PE32+ executable (DLL) (GUI) x86-64, for MS Windows"
+                file_output=$(file $out/lib/reaper_package_ext.dll)
+                echo "$file_output"
+                echo "$file_output" | grep -q "PE32+ executable (DLL) (GUI) x86-64, for MS Windows" || (echo "ERROR: not a PE32+ binary"; exit 1)
               '';
             });
         };

--- a/flake.nix
+++ b/flake.nix
@@ -374,51 +374,52 @@
               };
             };
           test-cargo-reaper-build-cross-windows =
-          let
-            rustcTarget = "x86_64-pc-windows-gnu";
-            crossPkgs = pkgs.pkgsCross.mingwW64;
-            mingwCC = crossPkgs.stdenv.cc;
-            crossCC = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-            crossCXX = "${mingwCC}/bin/${mingwCC.targetPrefix}c++";
-            rustWithWindowsTarget = fenix.packages.${system}.combine [
-              rustToolchain
-              (fenix.packages.${system}.targets.${rustcTarget}.toolchainOf {
-                channel = "1.87.0";
-                sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
-              }).rust-std
-            ];
-            craneLibCross =
-              let
-                craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
-              in
-              craneLib // (cargoReaper.crane { inherit craneLib; });
-            crossArgs = {
-              src = testFileset ./tests/plugin_manifests/package_manifest;
-              strictDeps = true;
-              nativeBuildInputs = [
-                mingwCC
-                pkgs.wine64
-              ];
-              CARGO_BUILD_TARGET = rustcTarget;
-              CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER =
-                "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-              "CC_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCC;
-              "CXX_${builtins.replaceStrings ["-"] ["_"] rustcTarget}" = crossCXX;
-              CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS =
-                "-L ${crossPkgs.windows.pthreads}/lib";
-            };
-            cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
-          in
-          craneLibCross.buildReaperExtension (crossArgs // {
-            cargoArtifacts = cargoArtifactsCross;
-            package = "package_manifest";
-            plugin = "reaper_package_ext";
-            target = rustcTarget;
-            doInstallCheck = true;
-            installCheckPhase = ''
-              test -f $out/lib/reaper_package_ext.dll
-            '';
-          });
+            let
+              rustcTarget = "x86_64-pc-windows-gnu";
+              craneLibCross =
+                let
+                  rustWithWindowsTarget = fenix.packages.${system}.combine [
+                    rustToolchain
+                    (fenix.packages.${system}.targets.${rustcTarget}.toolchainOf {
+                      channel = "1.87.0";
+                      sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
+                    }).rust-std
+                  ];
+                  craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
+                in
+                craneLib // (cargoReaper.crane { inherit craneLib; });
+              crossArgs =
+                let
+                  envTarget = builtins.replaceStrings [ "-" ] [ "_" ] rustcTarget;
+                  crossPkgs = pkgs.pkgsCross.mingwW64;
+                  mingwCC = crossPkgs.stdenv.cc;
+                in
+                {
+                  src = testFileset ./tests/plugin_manifests/package_manifest;
+                  strictDeps = true;
+                  nativeBuildInputs = [ mingwCC ];
+                  "CC_${envTarget}" = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
+                  "CXX_${envTarget}" = "${mingwCC}/bin/${mingwCC.targetPrefix}c++";
+                  CARGO_BUILD_TARGET = rustcTarget;
+                  CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
+                  CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-L ${crossPkgs.windows.pthreads}/lib";
+                };
+              cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
+            in
+            craneLibCross.buildReaperExtension (crossArgs // {
+              cargoArtifacts = cargoArtifactsCross;
+              package = "package_manifest";
+              plugin = "reaper_package_ext";
+              target = rustcTarget;
+              /* Checks could be ran using wine64, but in this case we only care
+              that the package was built and the output is the expected format */
+              doCheck = false;
+              doInstallCheck = true;
+              installCheckPhase = ''
+                test -f $out/lib/reaper_package_ext.dll
+                file $out/lib/reaper_package_ext.dll
+              '';
+            });
         };
 
       packages = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
     let
       pkgs = import nixpkgs {
         inherit system;
+        overlays = [ fenix.overlays.default ];
         config = {
           allowUnfree = true;
           allowUnsupportedSystem = true;
@@ -48,10 +49,12 @@
         inherit (self.packages.${system}) cargo-reaper;
       };
 
-      rustToolchain = fenix.packages.${system}.fromToolchainFile {
-        file = ./.rust-toolchain.toml;
-        sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
-      };
+      rustToolchain = pkgs.fenix.stable.withComponents [
+        "cargo"
+        "rustfmt"
+        "clippy"
+        "rust-analyzer"
+      ];
       craneLib =
         let
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
@@ -380,10 +383,7 @@
                 let
                   rustWithWindowsTarget = fenix.packages.${system}.combine [
                     rustToolchain
-                    (fenix.packages.${system}.targets.${rustcTarget}.toolchainOf {
-                      channel = "1.87.0";
-                      sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
-                    }).rust-std
+                    fenix.packages.${system}.targets.${rustcTarget}.stable.rust-std
                   ];
                   craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
                 in

--- a/flake.nix
+++ b/flake.nix
@@ -38,8 +38,11 @@
         inherit system;
         overlays = [ fenix.overlays.default ];
         config = {
-          allowUnfree = true;
-          allowUnsupportedSystem = true;
+          allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+            "reaper"
+            "win-sdk"
+            "xwin-fetch-msvc"
+          ];
           microsoftVisualStudioLicenseAccepted = true;
         };
       };
@@ -402,7 +405,10 @@
                   winSdk = pkgs.windows.sdk;
                   llvm = pkgs.llvmPackages;
                   # Flags forwarded to clang-cl by cc-rs so it can locate MSVC headers and libs.
-                  sdkCompilerFlags = "/vctoolsdir ${winSdk}/crt /winsdkdir ${winSdk}/sdk";
+                  sdkCompilerFlags = lib.concatStringsSep " " [
+                    "/vctoolsdir ${winSdk}/crt"
+                    "/winsdkdir ${winSdk}/sdk"
+                  ];
                 in
                 {
                   src = testFileset ./tests/plugin_manifests/package_manifest;

--- a/flake.nix
+++ b/flake.nix
@@ -400,34 +400,34 @@
                 craneLib // (cargoReaper.crane { inherit craneLib; });
               crossArgs =
                 let
+                  inherit (pkgs) llvmPackages windows;
                   envTarget = builtins.replaceStrings [ "-" ] [ "_" ] rustcTarget;
                   envTargetUpper = lib.toUpper envTarget;
-                  winSdk = pkgs.windows.sdk;
-                  llvm = pkgs.llvmPackages;
+                  CC = "${llvmPackages.clang-unwrapped}/bin/clang-cl";
                   # Flags forwarded to clang-cl by cc-rs so it can locate MSVC headers and libs.
-                  sdkCompilerFlags = lib.concatStringsSep " " [
-                    "/vctoolsdir ${winSdk}/crt"
-                    "/winsdkdir ${winSdk}/sdk"
+                  CFLAGS = lib.concatStringsSep " " [
+                    "/vctoolsdir ${windows.sdk}/crt"
+                    "/winsdkdir ${windows.sdk}/sdk"
                   ];
                 in
                 {
                   src = testFileset ./tests/plugin_manifests/package_manifest;
                   strictDeps = true;
-                  nativeBuildInputs = [
-                    llvm.clang-unwrapped # clang-cl (C/C++ compiler)
-                    llvm.bintools-unwrapped # lld-link (linker)
-                    llvm.llvm # llvm-lib (MSVC lib.exe equivalent, used by cc-rs)
+                  nativeBuildInputs = with llvmPackages; [
+                    clang-unwrapped # clang-cl (C/C++ compiler)
+                    bintools-unwrapped # lld-link (linker)
+                    llvm # llvm-lib (MSVC lib.exe equivalent, used by cc-rs)
                   ];
-                  "CC_${envTarget}" = "${llvm.clang-unwrapped}/bin/clang-cl";
-                  "CXX_${envTarget}" = "${llvm.clang-unwrapped}/bin/clang-cl";
-                  "CFLAGS_${envTarget}" = sdkCompilerFlags;
-                  "CXXFLAGS_${envTarget}" = sdkCompilerFlags;
-                  "AR_${envTarget}" = "${llvm.llvm}/bin/llvm-lib";
-                  "CARGO_TARGET_${envTargetUpper}_LINKER" = "${llvm.bintools-unwrapped}/bin/lld-link";
+                  "CC_${envTarget}" = CC;
+                  "CXX_${envTarget}" = CC;
+                  "CFLAGS_${envTarget}" = CFLAGS;
+                  "CXXFLAGS_${envTarget}" = CFLAGS;
+                  "AR_${envTarget}" = "${llvmPackages.llvm}/bin/llvm-lib";
+                  "CARGO_TARGET_${envTargetUpper}_LINKER" = "${llvmPackages.bintools-unwrapped}/bin/lld-link";
                   "CARGO_TARGET_${envTargetUpper}_RUSTFLAGS" = lib.concatStringsSep " " [
-                    "-C link-arg=/LIBPATH:${winSdk}/crt/lib/x64"
-                    "-C link-arg=/LIBPATH:${winSdk}/sdk/lib/ucrt/x64"
-                    "-C link-arg=/LIBPATH:${winSdk}/sdk/lib/um/x64"
+                    "-C link-arg=/LIBPATH:${windows.sdk}/crt/lib/x64"
+                    "-C link-arg=/LIBPATH:${windows.sdk}/sdk/lib/ucrt/x64"
+                    "-C link-arg=/LIBPATH:${windows.sdk}/sdk/lib/um/x64"
                   ];
                 };
               cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,8 @@
           commonTestArgs = src: {
             inherit src;
             strictDeps = true;
+          } // lib.optionalAttrs pkgs.stdenv.isLinux {
+            LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];
           };
 
           testFileset = root: lib.fileset.toSource {

--- a/flake.nix
+++ b/flake.nix
@@ -372,32 +372,39 @@
             };
           test-cargo-reaper-build-cross-windows =
             let
-              target = "x86_64-pc-windows-gnullvm";
+              inherit (pkgs.lib.systems.examples.mingw-ucrt-x86_64.rust) rustTarget;
               crossPkgs = pkgs.pkgsCross.mingw-ucrt-x86_64;
-              mingwCC = crossPkgs.clangStdenv.cc;
-              # LLVM libunwind compiled for Windows — required by the gnullvm target
-              winUnwind = crossPkgs.llvmPackages.libunwind;
+              mingwCC = crossPkgs.stdenv.cc;
+              crossCC = "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
+              crossCXX = "${mingwCC}/bin/${mingwCC.targetPrefix}c++";
+
               rustWithWindowsTarget = fenix.packages.${system}.combine [
                 rustToolchain
-                (fenix.packages.${system}.targets.${target}.toolchainOf {
+                (fenix.packages.${system}.targets.${rustTarget}.toolchainOf {
                   channel = "1.87.0";
                   sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
                 }).rust-std
               ];
               craneLibCross =
-                let base = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
-                in base // (cargoReaper.crane { craneLib = base; });
+                let
+                  craneLib = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
+                in
+                craneLib // (cargoReaper.crane { inherit craneLib; });
+
               crossArgs = {
                 src = testFileset ./tests/plugin_manifests/package_manifest;
                 strictDeps = true;
-                CARGO_BUILD_TARGET = target;
+                CARGO_BUILD_TARGET = rustTarget;
                 CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_LINKER =
                   "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-                # Force lld as the linker backend (required for gnullvm) and point it at
-                # LLVM's libunwind compiled for Windows (also required by gnullvm).
-                CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_RUSTFLAGS =
-                  "-C link-arg=-fuse-ld=lld -C link-arg=-L${winUnwind}/lib";
-                nativeBuildInputs = [ mingwCC pkgs.llvmPackages.lld ];
+                "CC_${rustTarget}" = crossCC;
+                "CXX_${rustTarget}" = crossCXX;
+
+                # # Force lld as the linker backend (required for gnullvm) and point it at
+                # # LLVM's libunwind compiled for Windows (also required by gnullvm).
+                # CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_RUSTFLAGS =
+                #   "-C link-arg=-fuse-ld=lld -C link-arg=-L${winUnwind}/lib";
+                nativeBuildInputs = [ mingwCC pkgs.llvmPackages.bintools ];
               };
               cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
             in
@@ -405,7 +412,7 @@
               cargoArtifacts = cargoArtifactsCross;
               package = "package_manifest";
               plugin = "reaper_package_ext";
-              target = target;
+              target = rustTarget;
               doInstallCheck = true;
               installCheckPhase = ''
                 test -f $out/lib/reaper_package_ext.dll

--- a/flake.nix
+++ b/flake.nix
@@ -370,6 +370,37 @@
                 plugin_name = "reaper_package_ext";
               };
             };
+          test-cargo-reaper-build-cross-windows =
+            let
+              target = "x86_64-pc-windows-gnu";
+              mingwCC = pkgs.pkgsCross.mingwW64.stdenv.cc;
+              rustWithWindowsTarget = fenix.packages.${system}.combine [
+                rustToolchain
+                fenix.packages.${system}.targets.${target}.latest.rust-std
+              ];
+              craneLibCross =
+                let base = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;
+                in base // (cargoReaper.crane { craneLib = base; });
+              crossArgs = {
+                src = testFileset ./tests/plugin_manifests/package_manifest;
+                strictDeps = true;
+                CARGO_BUILD_TARGET = target;
+                CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER =
+                  "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
+                nativeBuildInputs = [ mingwCC ];
+              };
+              cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
+            in
+            craneLibCross.buildReaperExtension (crossArgs // {
+              cargoArtifacts = cargoArtifactsCross;
+              package = "package_manifest";
+              plugin = "reaper_package_ext";
+              target = target;
+              doInstallCheck = true;
+              installCheckPhase = ''
+                test -f $out/lib/reaper_package_ext.dll
+              '';
+            });
         };
 
       packages = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -373,7 +373,7 @@
           test-cargo-reaper-build-cross-windows =
             let
               target = "x86_64-pc-windows-gnullvm";
-              mingwCC = pkgs.pkgsCross.mingw-ucrt-x86_64.llvmPackages.clang;
+              mingwCC = pkgs.pkgsCross.mingw-ucrt-x86_64.clangStdenv.cc;
               rustWithWindowsTarget = fenix.packages.${system}.combine [
                 rustToolchain
                 (fenix.packages.${system}.targets.${target}.toolchainOf {

--- a/flake.nix
+++ b/flake.nix
@@ -376,10 +376,10 @@
               mingwCC = pkgs.pkgsCross.mingw-ucrt-x86_64.stdenv.cc;
               rustWithWindowsTarget = fenix.packages.${system}.combine [
                 rustToolchain
-                (fenix.packages.${system}.toolchainOf {
+                (fenix.packages.${system}.targets.${target}.toolchainOf {
                   channel = "1.87.0";
                   sha256 = "sha256-KUm16pHj+cRedf8vxs/Hd2YWxpOrWZ7UOrwhILdSJBU=";
-                }).targets.${target}.rust-std
+                }).rust-std
               ];
               craneLibCross =
                 let base = (crane.mkLib pkgs).overrideToolchain rustWithWindowsTarget;

--- a/flake.nix
+++ b/flake.nix
@@ -373,7 +373,10 @@
           test-cargo-reaper-build-cross-windows =
             let
               target = "x86_64-pc-windows-gnullvm";
-              mingwCC = pkgs.pkgsCross.mingw-ucrt-x86_64.clangStdenv.cc;
+              crossPkgs = pkgs.pkgsCross.mingw-ucrt-x86_64;
+              mingwCC = crossPkgs.clangStdenv.cc;
+              # LLVM libunwind compiled for Windows — required by the gnullvm target
+              winUnwind = crossPkgs.llvmPackages.libunwind;
               rustWithWindowsTarget = fenix.packages.${system}.combine [
                 rustToolchain
                 (fenix.packages.${system}.targets.${target}.toolchainOf {
@@ -390,7 +393,11 @@
                 CARGO_BUILD_TARGET = target;
                 CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_LINKER =
                   "${mingwCC}/bin/${mingwCC.targetPrefix}cc";
-                nativeBuildInputs = [ mingwCC ];
+                # Force lld as the linker backend (required for gnullvm) and point it at
+                # LLVM's libunwind compiled for Windows (also required by gnullvm).
+                CARGO_TARGET_X86_64_PC_WINDOWS_GNULLVM_RUSTFLAGS =
+                  "-C link-arg=-fuse-ld=lld -C link-arg=-L${winUnwind}/lib";
+                nativeBuildInputs = [ mingwCC pkgs.llvmPackages.lld ];
               };
               cargoArtifactsCross = craneLibCross.buildDepsOnly crossArgs;
             in

--- a/flake.nix
+++ b/flake.nix
@@ -419,7 +419,11 @@
                 test -f $out/lib/reaper_package_ext.dll
                 file_output=$(file $out/lib/reaper_package_ext.dll)
                 echo "$file_output"
-                echo "$file_output" | grep -q "PE32+ executable (DLL) (GUI) x86-64, for MS Windows" || (echo "ERROR: not a PE32+ binary"; exit 1)
+                echo "$file_output" |
+                  grep -q "PE32+ executable for MS Windows 5.02 (DLL), x86-64" || {
+                    echo "ERROR: not a PE32+ binary";
+                    exit 1;
+                  }
               '';
             });
         };

--- a/flake.nix
+++ b/flake.nix
@@ -394,26 +394,27 @@
               crossArgs =
                 let
                   envTarget = builtins.replaceStrings [ "-" ] [ "_" ] rustcTarget;
+                  envTargetUpper = lib.toUpper envTarget;
                   winSdk = pkgs.windows.sdk;
                   llvm = pkgs.llvmPackages;
+                  # Flags forwarded to clang-cl by cc-rs so it can locate MSVC headers and libs.
+                  sdkCompilerFlags = "/vctoolsdir ${winSdk}/crt /winsdkdir ${winSdk}/sdk";
                 in
                 {
                   src = testFileset ./tests/plugin_manifests/package_manifest;
                   strictDeps = true;
                   nativeBuildInputs = [
-                    llvm.clang-unwrapped
-                    llvm.bintools-unwrapped
-                    llvm.llvm
+                    llvm.clang-unwrapped # clang-cl (C/C++ compiler)
+                    llvm.bintools-unwrapped # lld-link (linker)
+                    llvm.llvm # llvm-lib (MSVC lib.exe equivalent, used by cc-rs)
                   ];
                   "CC_${envTarget}" = "${llvm.clang-unwrapped}/bin/clang-cl";
                   "CXX_${envTarget}" = "${llvm.clang-unwrapped}/bin/clang-cl";
-                  # Pass SDK paths to clang-cl when the cc crate compiles C/C++ in build.rs scripts.
-                  "CFLAGS_${envTarget}" = "/vctoolsdir ${winSdk}/crt /winsdkdir ${winSdk}/sdk";
-                  "CXXFLAGS_${envTarget}" = "/vctoolsdir ${winSdk}/crt /winsdkdir ${winSdk}/sdk";
-                  # llvm-lib is the MSVC lib.exe equivalent; cc-rs invokes it with MSVC-style args.
+                  "CFLAGS_${envTarget}" = sdkCompilerFlags;
+                  "CXXFLAGS_${envTarget}" = sdkCompilerFlags;
                   "AR_${envTarget}" = "${llvm.llvm}/bin/llvm-lib";
-                  CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER = "${llvm.bintools-unwrapped}/bin/lld-link";
-                  CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS = lib.concatStringsSep " " [
+                  "CARGO_TARGET_${envTargetUpper}_LINKER" = "${llvm.bintools-unwrapped}/bin/lld-link";
+                  "CARGO_TARGET_${envTargetUpper}_RUSTFLAGS" = lib.concatStringsSep " " [
                     "-C link-arg=/LIBPATH:${winSdk}/crt/lib/x64"
                     "-C link-arg=/LIBPATH:${winSdk}/sdk/lib/ucrt/x64"
                     "-C link-arg=/LIBPATH:${winSdk}/sdk/lib/um/x64"

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
       inherit (pkgs) lib;
       cargoReaper = self.mkLib {
         inherit lib;
+        inherit (pkgs) stdenv;
         inherit (self.packages.${system}) cargo-reaper;
       };
 
@@ -108,8 +109,6 @@
           commonTestArgs = src: {
             inherit src;
             strictDeps = true;
-          } // lib.optionalAttrs pkgs.stdenv.isLinux {
-            LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];
           };
 
           testFileset = root: lib.fileset.toSource {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -50,10 +50,6 @@ in
       fileset = (craneLib.fileset or { }) // fileset;
 
       buildReaperExtension = { package, plugin ? package, target ? null, ... }@crateArgs:
-        let
-          targetFlag = lib.optionalString (target != null) "--target ${target}";
-          artifactDir = if target != null then "target/${target}/release" else "target/release";
-        in
         craneLib.buildPackage (crateArgs // {
           pname = package;
           nativeBuildInputs = (crateArgs.nativeBuildInputs or [ ]) ++ [
@@ -66,12 +62,14 @@ in
           buildPhaseCargoCommand = ''
             cargo reaper build --no-symlink \
               -p ${package} --lib \
-              --release ${targetFlag}
+              --release ${lib.optionalString (target != null) ''\
+              --target ${target}
+            ''}
           '';
           # Include extension plugin in the build result.
           installPhaseCommand = ''
             mkdir -p $out/lib
-            mv ${artifactDir}/${plugin}.* $out/lib
+            mv target${lib.optionalString (target != null) "/${target}"}/release/${plugin}.* $out/lib
           '';
           # Bypass crane checks for target install paths.
           doNotPostBuildInstallCargoBinaries = true;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,6 @@
 { lib
 , cargo-reaper
+, stdenv ? null
 }:
 let
   fileset.cargoReaperConfigFilter = from: lib.fileset.fileFilter (file: (builtins.match "\.?reaper\.toml" file.name) != null) from;
@@ -28,7 +29,7 @@ in
                 let
                   craneLib = inputs.crane.mkLib pkgs;
                   cargoReaper = inputs.cargo-reaper.mkLib {
-                    inherit (pkgs) lib;
+                    inherit (pkgs) lib stdenv;
                     inherit (inputs.cargo-reaper.packages.''${system}) cargo-reaper;
                   };
                 in
@@ -73,6 +74,14 @@ in
           '';
           # Bypass crane checks for target install paths.
           doNotPostBuildInstallCargoBinaries = true;
+        } // lib.optionalAttrs (stdenv != null && stdenv.isLinux) {
+          # Rust 1.96+ uses lld with -nodefaultlibs, which means libstdc++ is no
+          # longer implicitly findable at runtime in the Nix sandbox for test binaries
+          # compiled by cargo during the check phase.
+          LD_LIBRARY_PATH = lib.concatStringsSep ":" (
+            lib.optional (crateArgs ? LD_LIBRARY_PATH) crateArgs.LD_LIBRARY_PATH
+              ++ [ (lib.makeLibraryPath [ stdenv.cc.cc.lib ]) ]
+          );
         });
     };
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,5 @@
 { lib
 , cargo-reaper
-, stdenv ? null
 }:
 let
   fileset.cargoReaperConfigFilter = from: lib.fileset.fileFilter (file: (builtins.match "\.?reaper\.toml" file.name) != null) from;
@@ -29,7 +28,7 @@ in
                 let
                   craneLib = inputs.crane.mkLib pkgs;
                   cargoReaper = inputs.cargo-reaper.mkLib {
-                    inherit (pkgs) lib stdenv;
+                    inherit (pkgs) lib;
                     inherit (inputs.cargo-reaper.packages.''${system}) cargo-reaper;
                   };
                 in
@@ -74,14 +73,6 @@ in
           '';
           # Bypass crane checks for target install paths.
           doNotPostBuildInstallCargoBinaries = true;
-        } // lib.optionalAttrs (stdenv != null && stdenv.isLinux) {
-          # Rust 1.96+ uses lld with -nodefaultlibs, which means libstdc++ is no
-          # longer implicitly findable at runtime in the Nix sandbox for test binaries
-          # compiled by cargo during the check phase.
-          LD_LIBRARY_PATH = lib.concatStringsSep ":" (
-            lib.optional (crateArgs ? LD_LIBRARY_PATH) crateArgs.LD_LIBRARY_PATH
-              ++ [ (lib.makeLibraryPath [ stdenv.cc.cc.lib ]) ]
-          );
         });
     };
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -49,7 +49,11 @@ in
     }: {
       fileset = (craneLib.fileset or { }) // fileset;
 
-      buildReaperExtension = { package, plugin ? package, ... }@crateArgs:
+      buildReaperExtension = { package, plugin ? package, target ? null, ... }@crateArgs:
+        let
+          targetFlag = lib.optionalString (target != null) "--target ${target}";
+          artifactDir = if target != null then "target/${target}/release" else "target/release";
+        in
         craneLib.buildPackage (crateArgs // {
           pname = package;
           nativeBuildInputs = (crateArgs.nativeBuildInputs or [ ]) ++ [
@@ -62,12 +66,12 @@ in
           buildPhaseCargoCommand = ''
             cargo reaper build --no-symlink \
               -p ${package} --lib \
-              --release
+              --release ${targetFlag}
           '';
           # Include extension plugin in the build result.
           installPhaseCommand = ''
             mkdir -p $out/lib
-            mv target/release/${plugin}.* $out/lib
+            mv ${artifactDir}/${plugin}.* $out/lib
           '';
           # Bypass crane checks for target install paths.
           doNotPostBuildInstallCargoBinaries = true;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,8 @@ pub enum CargoReaperCommand {
     /// Compile REAPER extension plugin(s).
     Build {
         /// Do not symlink plugin(s) to the `UserPlugins` directory.
+        ///
+        /// If a cross compilation target is specified this is unconditionally true.
         #[arg(long)]
         no_symlink: bool,
 

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -8,21 +8,6 @@ use crate::{
     },
 };
 
-/// Parse `--target <triple>` / `--target=<triple>` from args,
-/// falling back to the `CARGO_BUILD_TARGET` environment variable.
-fn parse_target(args: &[String]) -> Option<String> {
-    let mut iter = args.iter();
-    while let Some(arg) = iter.next() {
-        if arg == "--target" {
-            return iter.next().cloned();
-        }
-        if let Some(val) = arg.strip_prefix("--target=") {
-            return Some(val.to_owned());
-        }
-    }
-    env::var("CARGO_BUILD_TARGET").ok()
-}
-
 /// Build a REAPER extension plugin.
 pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
     let project_root = find_project_root()?;
@@ -44,7 +29,7 @@ pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
                 .find(|arg| *arg == "--release")
                 .map_or("debug", |_| "release");
 
-            let target_triple = parse_target(&args);
+            let target_triple = env::var("CARGO_BUILD_TARGET").ok();
             let target_os = target_triple
                 .as_deref()
                 .and_then(TargetOs::from_triple)
@@ -87,11 +72,11 @@ pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
                         .join("target")
                         .join(triple)
                         .join(profile)
-                        .join(&from_lib_file_name),
+                        .join(&*from_lib_file_name),
                     None => project_root
                         .join("target")
                         .join(profile)
-                        .join(&from_lib_file_name),
+                        .join(&*from_lib_file_name),
                 };
 
                 if plugin_path.exists() {

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -72,17 +72,13 @@ pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
                 let to_lib_name_with_ext = target_os.add_plugin_ext(to_plugin_file_name.as_ref());
 
                 // Cross builds land in target/{triple}/{profile}/; native in target/{profile}/
-                let plugin_path = match target_triple.as_deref() {
-                    Some(triple) => project_root
-                        .join("target")
-                        .join(triple)
-                        .join(profile)
-                        .join(&*from_lib_file_name),
-                    None => project_root
-                        .join("target")
-                        .join(profile)
-                        .join(&*from_lib_file_name),
-                };
+                let plugin_path = target_triple
+                    .iter()
+                    .fold(project_root.join("target"), |plugin_path, target_triple| {
+                        plugin_path.join(target_triple)
+                    })
+                    .join(profile)
+                    .join(&*from_lib_file_name);
 
                 if plugin_path.exists() {
                     let plugin_path = rename_plugin(

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -29,7 +29,12 @@ pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
                 .find(|arg| *arg == "--release")
                 .map_or("debug", |_| "release");
 
-            let target_triple = env::var("CARGO_BUILD_TARGET").ok();
+            let target_triple = args
+                .iter()
+                .position(|arg| arg == "--target")
+                .and_then(|pos| args.get(pos + 1))
+                .cloned()
+                .or_else(|| env::var("CARGO_BUILD_TARGET").ok());
             let target_os = target_triple
                 .as_deref()
                 .and_then(TargetOs::from_triple)

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -72,22 +72,17 @@ pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
                 let to_lib_name_with_ext = target_os.add_plugin_ext(to_plugin_file_name.as_ref());
 
                 // Cross builds land in target/{triple}/{profile}/; native in target/{profile}/
-                let plugin_path = target_triple
+                let profile_path = target_triple
                     .iter()
                     .fold(project_root.join("target"), |plugin_path, target_triple| {
                         plugin_path.join(target_triple)
                     })
-                    .join(profile)
-                    .join(&*from_lib_file_name);
+                    .join(profile);
+                let plugin_path = profile_path.join(&*from_lib_file_name);
 
                 if plugin_path.exists() {
-                    let plugin_path = rename_plugin(
-                        &project_root,
-                        target_triple.as_deref(),
-                        profile,
-                        &plugin_path,
-                        &to_lib_name_with_ext,
-                    )?;
+                    let plugin_path =
+                        rename_plugin(&plugin_path, profile_path.join(to_lib_name_with_ext))?;
                     if target_triple.is_some() {
                         println!(
                             "{}: skipping symlink — cross compilation target specified ({})",

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -1,14 +1,27 @@
-use std::{fs, process};
+use std::{env, fs, process};
 
 use crate::{
     config::ReaperPluginConfig,
     error::TomlErrorEmitter,
     util::{
-        Colorize, find_project_root,
-        os::{add_plugin_ext, from_plugin_file_name, rename_plugin, symlink_plugin},
-        validate_plugin,
+        Colorize, TargetOs, find_project_root, os::symlink_plugin, rename_plugin, validate_plugin,
     },
 };
+
+/// Parse `--target <triple>` / `--target=<triple>` from args,
+/// falling back to the `CARGO_BUILD_TARGET` environment variable.
+fn parse_target(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--target" {
+            return iter.next().cloned();
+        }
+        if let Some(val) = arg.strip_prefix("--target=") {
+            return Some(val.to_owned());
+        }
+    }
+    env::var("CARGO_BUILD_TARGET").ok()
+}
 
 /// Build a REAPER extension plugin.
 pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
@@ -31,6 +44,12 @@ pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
                 .find(|arg| *arg == "--release")
                 .map_or("debug", |_| "release");
 
+            let target_triple = parse_target(&args);
+            let target_os = target_triple
+                .as_deref()
+                .and_then(TargetOs::from_triple)
+                .unwrap_or_else(TargetOs::host);
+
             for (to_plugin_file_name, plugin_manifest_dir) in config.extension_plugins().iter() {
                 let manifest_file = plugin_manifest_dir.get_ref().join("Cargo.toml");
                 let manifest_file_content = fs::read_to_string(&manifest_file).map_err(|err| {
@@ -49,23 +68,47 @@ pub(crate) fn build(no_symlink: bool, args: Vec<String>) -> anyhow::Result<()> {
                     &manifest_file_content,
                 )?;
 
-                let from_lib_name_with_ext = add_plugin_ext(
-                    &manifest
-                        .into_inner()
-                        .lib
-                        .map(|lib| lib.name.unwrap())
-                        .unwrap(),
-                );
-                let to_lib_name_with_ext = add_plugin_ext(to_plugin_file_name.as_ref());
-                let plugin_path = project_root
-                    .join("target")
-                    .join(profile)
-                    .join(from_plugin_file_name(&from_lib_name_with_ext));
+                let lib_name = manifest
+                    .into_inner()
+                    .lib
+                    .map(|lib| lib.name.unwrap())
+                    .unwrap();
+
+                // Cargo's output filename: lib<name>.so / lib<name>.dylib / <name>.dll
+                let from_lib_name_with_ext = target_os.add_plugin_ext(&lib_name);
+                let from_lib_file_name = target_os.plugin_file_name(&from_lib_name_with_ext);
+
+                // Desired output filename: reaper_<name>.so / .dylib / .dll
+                let to_lib_name_with_ext = target_os.add_plugin_ext(to_plugin_file_name.as_ref());
+
+                // Cross builds land in target/{triple}/{profile}/; native in target/{profile}/
+                let plugin_path = match target_triple.as_deref() {
+                    Some(triple) => project_root
+                        .join("target")
+                        .join(triple)
+                        .join(profile)
+                        .join(&from_lib_file_name),
+                    None => project_root
+                        .join("target")
+                        .join(profile)
+                        .join(&from_lib_file_name),
+                };
 
                 if plugin_path.exists() {
-                    let plugin_path =
-                        rename_plugin(&project_root, profile, &plugin_path, &to_lib_name_with_ext)?;
-                    if !no_symlink {
+                    let plugin_path = rename_plugin(
+                        &project_root,
+                        target_triple.as_deref(),
+                        profile,
+                        &plugin_path,
+                        &to_lib_name_with_ext,
+                    )?;
+                    if target_triple.is_some() {
+                        println!(
+                            "{}: skipping symlink — cross compilation target specified ({})",
+                            "warning".yellow().bold(),
+                            plugin_path.display()
+                        );
+                    } else if !no_symlink {
                         symlink_plugin(&plugin_path)?;
                     } else {
                         println!(

--- a/src/command/clean.rs
+++ b/src/command/clean.rs
@@ -3,10 +3,7 @@ use std::{collections, fs, path, process};
 use crate::{
     config::ReaperPluginConfig,
     error::TomlErrorEmitter,
-    util::{
-        Colorize, find_project_root,
-        os::{add_plugin_ext, remove_plugin_symlink},
-    },
+    util::{Colorize, TargetOs, find_project_root, os::remove_plugin_symlink},
 };
 
 /// Remove extension plugins from the `UserPlugins` directory.
@@ -42,8 +39,11 @@ pub(crate) fn clean(
     let mut removal_failures = 0;
     for plugin_name in plugins.keys() {
         println!("    {} {}", "Removing".magenta().bold(), plugin_name);
-        if let Err(err) = remove_plugin_symlink(plugin_name, &add_plugin_ext(plugin_name), dry_run)
-        {
+        if let Err(err) = remove_plugin_symlink(
+            plugin_name,
+            &TargetOs::add_plugin_ext(&TargetOs::host(), plugin_name),
+            dry_run,
+        ) {
             removal_failures += 1;
             eprintln!("{}: {err}", "error (benign)".magenta());
         }

--- a/src/command/new.rs
+++ b/src/command/new.rs
@@ -36,15 +36,15 @@ pub(crate) fn new_from_template(
 
     let cargo_toml_path = destination.join("cargo.toml");
     let mut cargo_toml = fs::read_to_string(&cargo_toml_path)?.parse::<toml_edit::DocumentMut>()?;
-    if let Some(package) = cargo_toml.get_mut("package") {
-        if let Some(name) = package.get_mut("name") {
-            *name = toml_edit::value(package_name);
-        }
+    if let Some(package) = cargo_toml.get_mut("package")
+        && let Some(name) = package.get_mut("name")
+    {
+        *name = toml_edit::value(package_name);
     }
-    if let Some(lib) = cargo_toml.get_mut("lib") {
-        if let Some(name) = lib.get_mut("name") {
-            *name = toml_edit::value(package_name);
-        }
+    if let Some(lib) = cargo_toml.get_mut("lib")
+        && let Some(name) = lib.get_mut("name")
+    {
+        *name = toml_edit::value(package_name);
     }
     fs::write(&cargo_toml_path, cargo_toml.to_string())
         .and_then(|_| fs::rename(&cargo_toml_path, destination.join("Cargo.toml")))?;

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -144,7 +144,7 @@ pub(crate) fn run_headless(
                         )
                         .map(|(xvfb, reaper)| ((xvfb, reaper), time::Instant::now()))?;
 
-                        let mut exit_code: i32 = keep_going.then_some(1).unwrap_or_default();
+                        let mut exit_code: i32 = if keep_going { 1 } else { Default::default() };
 
                         loop {
                             if let Some(window_title) = &window_title {
@@ -252,7 +252,7 @@ fn run_global_default_headless(
                     run_reaper_headless(&reaper, project, display, stdin, stdout, stderr)
                         .map(|(xvfb, reaper)| ((xvfb, reaper), time::Instant::now()))?;
 
-                let mut exit_code: i32 = keep_going.then_some(1).unwrap_or_default();
+                let mut exit_code: i32 = if keep_going { 1 } else { Default::default() };
 
                 loop {
                     if let Some(window_title) = &window_title {

--- a/src/util.rs
+++ b/src/util.rs
@@ -194,21 +194,32 @@ where
 
 /// Rename the resulting extension plugin, returning the new plugin path if it succeeds.
 ///
+/// When `target_triple` is `Some`, the artifact lives in `target/{triple}/{profile}/`;
+/// when `None`, it lives in `target/{profile}/` (native/host build).
+///
 /// > Note: This function is platform agnostic
 ///
 /// # Usage
 ///
 /// This is run automatically when running the `cargo reaper build` command.
-pub(crate) fn _rename_plugin(
+pub(crate) fn rename_plugin(
     project_root: &path::Path,
+    target_triple: Option<&str>,
     profile: &str,
     old_plugin_path: &path::PathBuf,
     plugin_name_to: &str,
 ) -> anyhow::Result<path::PathBuf> {
-    let new_plugin_path = project_root
-        .join("target")
-        .join(profile)
-        .join(plugin_name_to);
+    let new_plugin_path = match target_triple {
+        Some(triple) => project_root
+            .join("target")
+            .join(triple)
+            .join(profile)
+            .join(plugin_name_to),
+        None => project_root
+            .join("target")
+            .join(profile)
+            .join(plugin_name_to),
+    };
 
     fs::rename(old_plugin_path, &new_plugin_path)
         .map_err(|err| anyhow::anyhow!("failed to rename plugin: {err:?}"))?;
@@ -314,6 +325,62 @@ pub(crate) fn _remove_plugin_symlink(
     )
 }
 
+/// Runtime representation of the plugin target operating system.
+///
+/// Unlike the `os` module functions which are selected at compile time via `#[cfg(target_os)]`,
+/// this type is constructed at runtime from the `--target` triple, enabling cross-compilation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TargetOs {
+    Windows,
+    Linux,
+    MacOs,
+}
+
+impl TargetOs {
+    /// Returns the host OS via compile-time `cfg!`. Used when no `--target` is present.
+    pub(crate) fn host() -> Self {
+        if cfg!(target_os = "windows") {
+            Self::Windows
+        } else if cfg!(target_os = "linux") {
+            Self::Linux
+        } else {
+            Self::MacOs
+        }
+    }
+
+    /// Parses from a Rust target triple (e.g. `"x86_64-pc-windows-msvc"`).
+    /// Returns `None` for unrecognized triples; callers should fall back to `host()`.
+    pub(crate) fn from_triple(triple: &str) -> Option<Self> {
+        if triple.contains("windows") {
+            Some(Self::Windows)
+        } else if triple.contains("linux") {
+            Some(Self::Linux)
+        } else if triple.contains("darwin") || triple.contains("apple") {
+            Some(Self::MacOs)
+        } else {
+            None
+        }
+    }
+
+    /// Appends the platform-appropriate dynamic library file extension.
+    pub(crate) fn add_plugin_ext(&self, lib_name: &str) -> String {
+        match self {
+            Self::Windows => format!("{lib_name}.dll"),
+            Self::Linux => format!("{lib_name}.so"),
+            Self::MacOs => format!("{lib_name}.dylib"),
+        }
+    }
+
+    /// Applies the platform-appropriate library filename prefix transformation.
+    /// Unix targets prepend `lib`; Windows does not.
+    pub(crate) fn plugin_file_name(&self, lib_name: &str) -> String {
+        match self {
+            Self::Windows => lib_name.to_string(),
+            Self::Linux | Self::MacOs => format!("lib{lib_name}"),
+        }
+    }
+}
+
 #[cfg(target_os = "windows")]
 pub(crate) mod os {
     //! Operating system specific functionality for handling operations which require knownledge of
@@ -321,10 +388,7 @@ pub(crate) mod os {
 
     use std::{io, os, path};
 
-    use super::{_locate_global_default, _remove_plugin_symlink, _rename_plugin, _symlink_plugin};
-
-    /// The dynamically linked C library Windows extension
-    pub(crate) const WINDOWS_PLUGIN_EXT: &str = ".dll";
+    use super::{_locate_global_default, _remove_plugin_symlink, _symlink_plugin};
 
     /// The global default REAPER executable file path for `x86_64-windows` (64bit)
     #[cfg(target_arch = "x86_64")]
@@ -343,23 +407,6 @@ pub(crate) mod os {
             let reaper = path::PathBuf::from(GLOBAL_DEFAULT_PATH);
             (reaper.exists()).then_some(reaper)
         })
-    }
-
-    pub(crate) fn from_plugin_file_name(lib_name: &str) -> String {
-        lib_name.to_string()
-    }
-
-    pub(crate) fn add_plugin_ext(lib_name: &str) -> String {
-        format!("{lib_name}{WINDOWS_PLUGIN_EXT}")
-    }
-
-    pub(crate) fn rename_plugin(
-        project_root: &path::Path,
-        profile: &str,
-        old_plugin_path: &path::PathBuf,
-        plugin_name_to: &str,
-    ) -> anyhow::Result<path::PathBuf> {
-        _rename_plugin(project_root, profile, old_plugin_path, plugin_name_to)
     }
 
     pub(crate) fn symlink_plugin(plugin_path: &path::PathBuf) -> anyhow::Result<()> {
@@ -408,33 +455,10 @@ pub(crate) mod os {
 
     use std::{io, os, path};
 
-    use super::{
-        _locate_global_default, _remove_plugin_symlink, _rename_plugin, _symlink_plugin,
-        BINARY_NAME,
-    };
-
-    /// The dynamically linked C library Linux extension
-    pub(crate) const LINUX_PLUGIN_EXT: &str = ".so";
+    use super::{_locate_global_default, _remove_plugin_symlink, _symlink_plugin, BINARY_NAME};
 
     pub(crate) fn locate_global_default() -> io::Result<path::PathBuf> {
         _locate_global_default(|| which::which_global(BINARY_NAME).ok())
-    }
-
-    pub(crate) fn from_plugin_file_name(lib_name: &str) -> String {
-        format!("lib{lib_name}")
-    }
-
-    pub(crate) fn add_plugin_ext(lib_name: &str) -> String {
-        format!("{lib_name}{LINUX_PLUGIN_EXT}")
-    }
-
-    pub(crate) fn rename_plugin(
-        project_root: &path::Path,
-        profile: &str,
-        old_plugin_path: &path::PathBuf,
-        plugin_name_to: &str,
-    ) -> anyhow::Result<path::PathBuf> {
-        _rename_plugin(project_root, profile, old_plugin_path, plugin_name_to)
     }
 
     pub(crate) fn symlink_plugin(plugin_path: &path::PathBuf) -> anyhow::Result<()> {
@@ -472,13 +496,9 @@ pub(crate) mod os {
 
     use std::{io, os, path};
 
-    use super::{_locate_global_default, _remove_plugin_symlink, _rename_plugin, _symlink_plugin};
-
-    /// The dynamically linked C library MacOS (Darwin) extension
-    pub(crate) const DARWIN_PLUGIN_EXT: &str = ".dylib";
+    use super::{_locate_global_default, _remove_plugin_symlink, _symlink_plugin};
 
     /// The global default REAPER executable file path for `x86_64-darwin` (Intel) and `aarch64-darwin` (Apple Silicon)
-    #[cfg(target_os = "macos")]
     pub(crate) const GLOBAL_DEFAULT_PATH: &str = "/Applications/REAPER.app/Contents/MacOS/REAPER";
 
     pub(crate) fn locate_global_default() -> io::Result<path::PathBuf> {
@@ -486,23 +506,6 @@ pub(crate) mod os {
             let reaper = path::PathBuf::from(GLOBAL_DEFAULT_PATH);
             (reaper.exists()).then_some(reaper)
         })
-    }
-
-    pub(crate) fn from_plugin_file_name(lib_name: &str) -> String {
-        format!("lib{lib_name}")
-    }
-
-    pub(crate) fn add_plugin_ext(lib_name: &str) -> String {
-        format!("{lib_name}{DARWIN_PLUGIN_EXT}")
-    }
-
-    pub(crate) fn rename_plugin(
-        project_root: &path::Path,
-        profile: &str,
-        old_plugin_path: &path::PathBuf,
-        plugin_name_to: &str,
-    ) -> anyhow::Result<path::PathBuf> {
-        _rename_plugin(project_root, profile, old_plugin_path, plugin_name_to)
     }
 
     pub(crate) fn symlink_plugin(plugin_path: &path::PathBuf) -> anyhow::Result<()> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -54,8 +54,8 @@ impl PluginManifest {
 impl fmt::Display for PluginManifest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} v{}", self.name.blue(), self.version)?;
-        if self.description.is_some() {
-            write!(f, " -- {}", self.description.as_ref().unwrap())?;
+        if let Some(ref description) = self.description {
+            write!(f, " -- {}", description)?;
         }
         if !self.authors.is_empty() {
             write!(f, "\n\nAuthored by: {}", self.authors.join(", "))?;
@@ -337,14 +337,13 @@ pub(crate) enum TargetOs {
 }
 
 impl TargetOs {
-    /// Returns the host OS via compile-time `cfg!`. Used when no `--target` is present.
+    /// Returns the host OS via compile-time macro. Used when no `--target` is present.
     pub(crate) fn host() -> Self {
-        if cfg!(target_os = "windows") {
-            Self::Windows
-        } else if cfg!(target_os = "linux") {
-            Self::Linux
-        } else {
-            Self::MacOs
+        cfg_select! {
+           target_os = "windows" => Self::Windows,
+           target_os = "linux" => Self::Linux,
+           target_os = "macos" => Self::MacOs,
+           _ => compile_error!("Unsupported host platform"),
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::{env, fmt, fs, io, path};
+use std::{borrow, env, fmt, fs, io, path};
 
 pub(crate) use colored::Colorize;
 
@@ -209,17 +209,13 @@ pub(crate) fn rename_plugin(
     old_plugin_path: &path::PathBuf,
     plugin_name_to: &str,
 ) -> anyhow::Result<path::PathBuf> {
-    let new_plugin_path = match target_triple {
-        Some(triple) => project_root
-            .join("target")
-            .join(triple)
-            .join(profile)
-            .join(plugin_name_to),
-        None => project_root
-            .join("target")
-            .join(profile)
-            .join(plugin_name_to),
-    };
+    let new_plugin_path = target_triple
+        .iter()
+        .fold(project_root.join("target"), |plugin_path, target_triple| {
+            plugin_path.join(target_triple)
+        })
+        .join(profile)
+        .join(plugin_name_to);
 
     fs::rename(old_plugin_path, &new_plugin_path)
         .map_err(|err| anyhow::anyhow!("failed to rename plugin: {err:?}"))?;
@@ -372,10 +368,10 @@ impl TargetOs {
 
     /// Applies the platform-appropriate library filename prefix transformation.
     /// Unix targets prepend `lib`; Windows does not.
-    pub(crate) fn plugin_file_name(&self, lib_name: &str) -> String {
+    pub(crate) fn plugin_file_name<'a>(&self, lib_name: &'a str) -> borrow::Cow<'a, str> {
         match self {
-            Self::Windows => lib_name.to_string(),
-            Self::Linux | Self::MacOs => format!("lib{lib_name}"),
+            Self::Windows => borrow::Cow::Borrowed(lib_name),
+            Self::Linux | Self::MacOs => borrow::Cow::Owned(format!("lib{lib_name}")),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -221,7 +221,7 @@ pub(crate) fn rename_plugin(
         .map_err(|err| anyhow::anyhow!("failed to rename plugin: {err:?}"))?;
 
     println!(
-        "     {} {} → {}",
+        "     {} {} -> {}",
         "Renamed".green().bold(),
         old_plugin_path.display(),
         new_plugin_path.display()
@@ -281,7 +281,7 @@ where
         .map_err(|err| anyhow::anyhow!("failed to link extension plugin: {err:?}"))?;
 
     println!(
-        "     {} symbolic link {} → {}",
+        "     {} symbolic link {} -> {}",
         "Created".green().bold(),
         symlink_path.display(),
         plugin_path.display()

--- a/src/util.rs
+++ b/src/util.rs
@@ -203,31 +203,20 @@ where
 ///
 /// This is run automatically when running the `cargo reaper build` command.
 pub(crate) fn rename_plugin(
-    project_root: &path::Path,
-    target_triple: Option<&str>,
-    profile: &str,
-    old_plugin_path: &path::PathBuf,
-    plugin_name_to: &str,
+    plugin_path_from: &path::PathBuf,
+    plugin_path_to: path::PathBuf,
 ) -> anyhow::Result<path::PathBuf> {
-    let new_plugin_path = target_triple
-        .iter()
-        .fold(project_root.join("target"), |plugin_path, target_triple| {
-            plugin_path.join(target_triple)
-        })
-        .join(profile)
-        .join(plugin_name_to);
-
-    fs::rename(old_plugin_path, &new_plugin_path)
+    fs::rename(plugin_path_from, &plugin_path_to)
         .map_err(|err| anyhow::anyhow!("failed to rename plugin: {err:?}"))?;
 
     println!(
         "     {} {} -> {}",
         "Renamed".green().bold(),
-        old_plugin_path.display(),
-        new_plugin_path.display()
+        plugin_path_from.display(),
+        plugin_path_to.display()
     );
 
-    Ok(new_plugin_path)
+    Ok(plugin_path_to)
 }
 
 /// Symlink the REAPER extension plugin to the `UserPlugins` directory.

--- a/tests/plugin_manifests/package_manifest/Cargo.lock
+++ b/tests/plugin_manifests/package_manifest/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -28,9 +28,9 @@ checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -102,7 +102,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -158,15 +158,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "helgoboss-midi"
@@ -187,9 +196,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -213,14 +222,14 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -234,15 +243,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"
@@ -291,7 +300,7 @@ dependencies = [
  "kinded",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "urlencoding",
 ]
 
@@ -348,7 +357,7 @@ dependencies = [
 [[package]]
 name = "reaper-common-types"
 version = "0.1.0"
-source = "git+https://github.com/Cloud-Scythe-Labs/reaper-rs.git?branch=eureka-cpu%2F100#4d630b51d752a1d2049a7ba5a98ee37679cb53ac"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "nutype",
  "serde",
@@ -357,7 +366,7 @@ dependencies = [
 [[package]]
 name = "reaper-low"
 version = "0.1.0"
-source = "git+https://github.com/Cloud-Scythe-Labs/reaper-rs.git?branch=eureka-cpu%2F100#4d630b51d752a1d2049a7ba5a98ee37679cb53ac"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "c_str_macro",
  "cc",
@@ -373,7 +382,7 @@ dependencies = [
 [[package]]
 name = "reaper-macros"
 version = "0.1.0"
-source = "git+https://github.com/Cloud-Scythe-Labs/reaper-rs.git?branch=eureka-cpu%2F100#4d630b51d752a1d2049a7ba5a98ee37679cb53ac"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "darling",
  "quote",
@@ -383,7 +392,7 @@ dependencies = [
 [[package]]
 name = "reaper-medium"
 version = "0.1.0"
-source = "git+https://github.com/Cloud-Scythe-Labs/reaper-rs.git?branch=eureka-cpu%2F100#4d630b51d752a1d2049a7ba5a98ee37679cb53ac"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "camino",
  "derive_more",
@@ -415,7 +424,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -429,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -460,14 +469,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "strsim"
@@ -488,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -533,7 +542,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -553,9 +562,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "urlencoding"

--- a/tests/plugin_manifests/package_manifest/Cargo.lock
+++ b/tests/plugin_manifests/package_manifest/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 [[package]]
 name = "reaper-common-types"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/Cloud-Scythe-Labs/reaper-rs.git?branch=eureka-cpu%2F100#4d630b51d752a1d2049a7ba5a98ee37679cb53ac"
 dependencies = [
  "nutype",
  "serde",
@@ -357,7 +357,7 @@ dependencies = [
 [[package]]
 name = "reaper-low"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/Cloud-Scythe-Labs/reaper-rs.git?branch=eureka-cpu%2F100#4d630b51d752a1d2049a7ba5a98ee37679cb53ac"
 dependencies = [
  "c_str_macro",
  "cc",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "reaper-macros"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/Cloud-Scythe-Labs/reaper-rs.git?branch=eureka-cpu%2F100#4d630b51d752a1d2049a7ba5a98ee37679cb53ac"
 dependencies = [
  "darling",
  "quote",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "reaper-medium"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/Cloud-Scythe-Labs/reaper-rs.git?branch=eureka-cpu%2F100#4d630b51d752a1d2049a7ba5a98ee37679cb53ac"
 dependencies = [
  "camino",
  "derive_more",

--- a/tests/plugin_manifests/package_manifest/Cargo.toml
+++ b/tests/plugin_manifests/package_manifest/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 fragile = "2.0.1"
-reaper-low = { git = "https://github.com/Cloud-Scythe-Labs/reaper-rs.git", branch = "eureka-cpu/100" }
-reaper-macros = { git = "https://github.com/Cloud-Scythe-Labs/reaper-rs.git", branch = "eureka-cpu/100" }
-reaper-medium = { git = "https://github.com/Cloud-Scythe-Labs/reaper-rs.git", branch = "eureka-cpu/100" }
+reaper-low = { git = "https://github.com/helgoboss/reaper-rs.git", branch = "master" }
+reaper-macros = { git = "https://github.com/helgoboss/reaper-rs.git", branch = "master" }
+reaper-medium = { git = "https://github.com/helgoboss/reaper-rs.git", branch = "master" }
 
 [lib]
 name = "_package_extension"

--- a/tests/plugin_manifests/package_manifest/Cargo.toml
+++ b/tests/plugin_manifests/package_manifest/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 fragile = "2.0.1"
-reaper-low = { git = "https://github.com/helgoboss/reaper-rs.git", branch = "master" }
-reaper-macros = { git = "https://github.com/helgoboss/reaper-rs.git", branch = "master" }
-reaper-medium = { git = "https://github.com/helgoboss/reaper-rs.git", branch = "master" }
+reaper-low = { git = "https://github.com/Cloud-Scythe-Labs/reaper-rs.git", branch = "eureka-cpu/100" }
+reaper-macros = { git = "https://github.com/Cloud-Scythe-Labs/reaper-rs.git", branch = "eureka-cpu/100" }
+reaper-medium = { git = "https://github.com/Cloud-Scythe-Labs/reaper-rs.git", branch = "eureka-cpu/100" }
 
 [lib]
 name = "_package_extension"

--- a/tests/plugin_manifests/workspace_manifest/Cargo.lock
+++ b/tests/plugin_manifests/workspace_manifest/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -28,9 +28,9 @@ checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -102,7 +102,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -188,15 +188,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "helgoboss-midi"
@@ -217,9 +226,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -243,14 +252,14 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -264,15 +273,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"
@@ -321,7 +330,7 @@ dependencies = [
  "kinded",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "urlencoding",
 ]
 
@@ -368,7 +377,7 @@ dependencies = [
 [[package]]
 name = "reaper-common-types"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "nutype",
  "serde",
@@ -377,7 +386,7 @@ dependencies = [
 [[package]]
 name = "reaper-low"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "c_str_macro",
  "cc",
@@ -393,7 +402,7 @@ dependencies = [
 [[package]]
 name = "reaper-macros"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "darling",
  "quote",
@@ -403,7 +412,7 @@ dependencies = [
 [[package]]
 name = "reaper-medium"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "camino",
  "derive_more",
@@ -435,7 +444,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -449,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -480,14 +489,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "strsim"
@@ -508,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -553,7 +562,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -573,9 +582,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "urlencoding"

--- a/tests/plugin_manifests/workspace_package_manifest/Cargo.lock
+++ b/tests/plugin_manifests/workspace_package_manifest/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -28,9 +28,9 @@ checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -102,7 +102,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -158,15 +158,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "helgoboss-midi"
@@ -187,9 +196,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -213,14 +222,14 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -234,15 +243,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"
@@ -291,7 +300,7 @@ dependencies = [
  "kinded",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "urlencoding",
 ]
 
@@ -338,7 +347,7 @@ dependencies = [
 [[package]]
 name = "reaper-common-types"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "nutype",
  "serde",
@@ -347,7 +356,7 @@ dependencies = [
 [[package]]
 name = "reaper-low"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "c_str_macro",
  "cc",
@@ -363,7 +372,7 @@ dependencies = [
 [[package]]
 name = "reaper-macros"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "darling",
  "quote",
@@ -373,7 +382,7 @@ dependencies = [
 [[package]]
 name = "reaper-medium"
 version = "0.1.0"
-source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#5d9f6f620d921c2dd2ebe5e9f5865b647d7533dc"
+source = "git+https://github.com/helgoboss/reaper-rs.git?branch=master#955d6a2e8ab3e6ea1251357ee14210cd88d4c2ae"
 dependencies = [
  "camino",
  "derive_more",
@@ -405,7 +414,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -419,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -450,14 +459,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "strsim"
@@ -478,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -523,7 +532,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -543,9 +552,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "urlencoding"


### PR DESCRIPTION
Closes #23

----
## Summary by Gitar

- **Cross-compilation support:**
  - Added `TargetOs` enum to dynamically handle platform-specific naming and extensions based on target triples.
  - Updated `build` command to parse `--target` flags or `CARGO_BUILD_TARGET` for output path resolution.
  - Modified output path logic in `rename_plugin` to support `target/{triple}/{profile}/` directories.


<sub>This will update automatically on new commits.</sub>