### PR TITLE
ci: build docs as a derivation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,11 +17,9 @@ jobs:
             extra-substituters = https://cloud-scythe-labs.cachix.org
             extra-trusted-public-keys = cloud-scythe-labs.cachix.org-1:I+IM+x2gGlmNjUMZOsyHJpxIzmAi7XhZNmTVijGjsLw=
       - name: Build Docs
-        run: |
-          nix-shell -E 'let pkgs = (import ./release.nix { }).pkgs; in pkgs.mkShell { buildInputs = [ pkgs.mdbook ]; }' \
-            --run "mdbook build docs"
+        run: nix-build release.nix -A docs -o docs-result
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/book
+          publish_dir: ./docs-result

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,9 @@ jobs:
             extra-substituters = https://cloud-scythe-labs.cachix.org
             extra-trusted-public-keys = cloud-scythe-labs.cachix.org-1:I+IM+x2gGlmNjUMZOsyHJpxIzmAi7XhZNmTVijGjsLw=
       - name: Build Docs
-        run: nix-shell -p mdbook --run "mdbook build docs"
+        run: |
+          nix-shell -E 'let pkgs = (import ./release.nix { }).pkgs; in pkgs.mkShell { buildInputs = [ pkgs.mdbook ]; }' \
+            --run "mdbook build docs"
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/release.nix
+++ b/release.nix
@@ -35,6 +35,22 @@ in
 
   fmt = treefmtEval.config.build.wrapper;
 
+  docs = pkgs.stdenvNoCC.mkDerivation {
+    pname = "cargo-reaper-docs";
+    version = pkgs.cargo-reaper.version;
+    src = lib.cleanSourceWith {
+      src = lib.cleanSource ./docs;
+      filter = path: type: baseNameOf path != "book";
+    };
+    nativeBuildInputs = [ pkgs.mdbook ];
+    buildPhase = ''
+      runHook preBuild
+      mdbook build --dest-dir $out .
+      runHook postBuild
+    '';
+    dontInstall = true;
+  };
+
   checks = {
     inherit (pkgs) cargo-reaper;
     inherit (pkgs.cargo-reaper.passthru.tests)


### PR DESCRIPTION
Build docs as a derivation and replace the nix-shell invocation in CI